### PR TITLE
feat: TileItem Clustering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "wkt",
 ]
 
 [[package]]
@@ -2513,6 +2514,18 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "wkt"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c2252781f8927974e8ba6a67c965a759a2b88ea2b1825f6862426bbb1c8f41"
+dependencies = [
+ "geo-types",
+ "log",
+ "num-traits",
+ "thiserror",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "env_logger 0.10.2",
  "fast_hilbert",
  "flate2",
+ "geo",
  "log",
  "memmap2 0.9.4",
  "opentelemetry",
@@ -56,6 +57,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +76,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-tzdata"
@@ -133,6 +152,15 @@ name = "anyhow"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "async-stream"
@@ -440,6 +468,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
+name = "earcutr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
+dependencies = [
+ "itertools",
+ "num-traits",
+]
+
+[[package]]
 name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +566,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float_next_after"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +651,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f811f663912a69249fa620dcd2a005db7254529da2d8a0b23942e81f47084501"
+dependencies = [
+ "earcutr",
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "log",
+ "num-traits",
+ "robust",
+ "rstar",
+ "spade",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff16065e5720f376fbced200a5ae0f47ace85fd70b7e54269790281353b6d61"
+dependencies = [
+ "approx",
+ "num-traits",
+ "rstar",
+ "serde",
+]
+
+[[package]]
+name = "geographiclib-rs"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e5ed84f8089c70234b0a8e0aedb6dc733671612ddc0d37c6066052f9781960"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,6 +750,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heapless"
@@ -1491,6 +1577,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "robust"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf4a6aa5f6d6888f39e980649f3ad6b666acdce1d78e95b8a2cb076e687ae30"
+
+[[package]]
 name = "rstar"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,6 +1822,18 @@ checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "spade"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f4ec45f91925e2c9ab3b6a857ee9ed36916990df76a1c475d783a328e247cc8"
+dependencies = [
+ "hashbrown 0.14.5",
+ "num-traits",
+ "robust",
+ "smallvec",
 ]
 
 [[package]]
@@ -2135,6 +2239,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2403,6 +2513,26 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ flate2 = { version = "1.0.30", features = ["zlib-ng"], optional = true }
 memmap2 = { version = "0.9.4", optional = true }
 fast_hilbert = {  version = "2.0.0", optional = true }
 scc = { version = "2.1.1", optional = true }
+geo = "0.28.0"
 
 [build-dependencies]
 tonic-build = { version = "0.11.0", features = ["prost"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ memmap2 = { version = "0.9.4", optional = true }
 fast_hilbert = {  version = "2.0.0", optional = true }
 scc = { version = "2.1.1", optional = true }
 geo = "0.28.0"
+wkt = "0.10.3"
 
 [build-dependencies]
 tonic-build = { version = "0.11.0", features = ["prost"] }

--- a/src/geo/cluster/haversine.rs
+++ b/src/geo/cluster/haversine.rs
@@ -1,6 +1,6 @@
-use crate::geo::{MEAN_EARTH_RADIUS, Point};
+use crate::geo::{MEAN_EARTH_RADIUS, TileItem};
 
-pub fn haversine_distance<const N: usize, P, T: Point<P, N>>(lhs: &T, rhs: &T) -> f64 {
+pub fn haversine_distance<const N: usize, P, T: TileItem<P, N>>(lhs: &T, rhs: &T) -> f64 {
     let (l_lat, l_lng) = lhs.lat_lng().expand();
     let (r_lat, r_lng) = rhs.lat_lng().expand();
 

--- a/src/geo/cluster/haversine.rs
+++ b/src/geo/cluster/haversine.rs
@@ -1,0 +1,19 @@
+use crate::geo::{MEAN_EARTH_RADIUS, Point};
+
+pub fn haversine_distance<const N: usize, P, T: Point<P, N>>(lhs: &T, rhs: &T) -> f64 {
+    let (l_lat, l_lng) = lhs.lat_lng().expand();
+    let (r_lat, r_lng) = rhs.lat_lng().expand();
+
+    let two: f64 = 1f64 + 1f64;
+    let theta1 = l_lng.to_radians();
+    let theta2 = r_lng.to_radians();
+    let delta_theta = (r_lng - l_lng).to_radians();
+    let delta_lambda = (r_lat - l_lat).to_radians();
+
+    let a = (delta_theta / two).sin().powi(2)
+        + theta1.cos() * theta2.cos()
+        * (delta_lambda / two).sin().powi(2);
+
+    let c = two * a.sqrt().asin();
+    MEAN_EARTH_RADIUS * c
+}

--- a/src/geo/cluster/mod.rs
+++ b/src/geo/cluster/mod.rs
@@ -1,0 +1,2 @@
+pub mod haversine;
+pub mod set;

--- a/src/geo/cluster/set.rs
+++ b/src/geo/cluster/set.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use geo::{Centroid, ConvexHull, LineString, Polygon};
-use log::{error, info};
+use log::{error};
 use wkt::ToWkt;
 
 use crate::codec::mvt::Value;
@@ -68,8 +68,6 @@ impl<const N: usize, P, T: TileItem<P, N>> TryFrom<(Vec<T>, u8)> for Clustered<N
         );
 
         let convex_hull = polygon.convex_hull();
-        info!("Polygon: {:?}", convex_hull.wkt_string());
-
         let centroid = convex_hull.centroid()
             .ok_or(GeoError::InvalidCoordinate("".to_string()))?;
 

--- a/src/geo/cluster/set.rs
+++ b/src/geo/cluster/set.rs
@@ -1,0 +1,212 @@
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use geo::{Centroid, ConvexHull, LineString, Polygon};
+
+use crate::geo::cluster::haversine::haversine_distance;
+use crate::geo::{LatLng, Point};
+use crate::geo::error::GeoError;
+
+#[derive(PartialEq, Clone)]
+pub enum Classification {
+    Core(usize),
+    Edge(usize),
+    Noise,
+}
+
+pub struct Clustered<const N: usize, P, T: Point<P, N>> {
+    pub id: u32,
+    pub points: Vec<T>,
+
+    centroid: LatLng,
+    convex_hull: Polygon,
+
+    phantom_data: PhantomData<P>
+}
+
+pub struct Cluster<const N: usize, P, T: Point<P, N>> {
+    // a.k.a Spillage
+    pub noise: Vec<T>,
+    pub clustered: Vec<Clustered<N, P, T>>,
+
+    phantom_data: PhantomData<P>
+}
+
+impl<const N: usize, P, T: Point<P, N>> TryFrom<(Vec<T>, u8)> for Clustered<N, P, T> {
+    type Error = GeoError;
+
+    fn try_from((value, zoom): (Vec<T>, u8)) -> Result<Self, Self::Error> {
+        let polygon = Polygon::new(
+            LineString::from_iter(value.iter().map(|p| p.lat_lng().slice())),
+            vec![],
+        );
+
+        let convex_hull = polygon.convex_hull();
+        let centroid = convex_hull.centroid().ok_or(GeoError::InvalidCoordinate("".to_string()))?;
+        let lat_lng = LatLng::from_degree(centroid.x(), centroid.y())?;
+
+        Ok(Self {
+            id: lat_lng.hash(zoom),
+            centroid: lat_lng,
+
+            points: value,
+            convex_hull,
+            phantom_data: PhantomData::default()
+        })
+    }
+}
+
+impl<const N: usize, P, T: Point<P, N>> From<Vec<T>> for Cluster<N, P, T> {
+    fn from(value: Vec<T>) -> Self {
+        Self {
+            noise: value,
+            clustered: Vec::new(),
+            phantom_data: PhantomData::default()
+        }
+    }
+}
+
+impl<const N: usize, P, T: Point<P, N>> TryFrom<(Vec<(u32, T)>, u8)> for Cluster<N, P, T> {
+    type Error = GeoError;
+
+    fn try_from((value, zoom): (Vec<(u32, T)>, u8)) -> Result<Self, GeoError> {
+        let mut hashmap: HashMap<u32, Vec<T>> = HashMap::new();
+        value
+            .into_iter()
+            .for_each(|(hash, p)| match hashmap.get_mut(&hash) {
+                None => { hashmap.insert(hash, vec![p]); }
+                Some(group) => { group.push(p); }
+            });
+
+        let grouped: Vec<Vec<T>> = hashmap.into_values().collect();
+
+        let mut clustered: Vec<Clustered<N, P, T>> = vec![];
+        let mut noise: Vec<T> = vec![];
+
+        grouped
+            .into_iter()
+            .for_each(|mut group| {
+                if group.len() >= 3 {
+                    if let Ok(cluster) = Clustered::try_from((group, zoom)) {
+                        clustered.push(cluster);
+                    }
+                } else {
+                    noise.push(group.remove(0));
+                }
+            });
+
+        Ok(Self { clustered, noise, phantom_data: PhantomData::default() })
+    }
+}
+
+pub struct IntoCluster<const N: usize, P, T: Point<P, N>> {
+    pub epsilon: f64,
+    pub c_capacity: usize,
+
+    distance: for<'a, 'b> fn(&'a T, &'a T) -> f64,
+    c: Vec<Classification>,
+    v: Vec<bool>,
+
+    phantom_data: PhantomData<P>
+}
+
+impl<const N: usize, P, T: Point<P, N>> Default for IntoCluster<N, P, T> {
+    fn default() -> Self {
+        IntoCluster {
+            epsilon: 1.0,
+            c_capacity: 10,
+            distance: haversine_distance,
+            c: Vec::new(),
+            v: Vec::new(),
+            phantom_data: PhantomData::default()
+        }
+    }
+}
+
+impl<const N: usize, P, T: Point<P, N>> IntoCluster<N, P, T> {
+    pub fn new() -> Self {
+        IntoCluster::default()
+    }
+
+    pub fn distance(self, distance_fn: fn(_: &T, _: &T) -> f64) -> Self {
+        Self {
+            distance: distance_fn,
+            ..self
+        }
+    }
+
+    #[inline]
+    fn range_query(&self, sample: &T, population: &[T]) -> Vec<usize> {
+        population
+            .iter()
+            .enumerate()
+            .filter(|(_, pt)| (self.distance)(sample, pt) < self.epsilon)
+            .map(|(idx, _)| idx)
+            .collect()
+    }
+
+    fn expand_cluster(
+        &mut self,
+        population: &[T],
+        queue: &mut Vec<usize>,
+        cluster: usize,
+    ) -> bool {
+        let mut new_cluster = false;
+        while let Some(ind) = queue.pop() {
+            let neighbors = self.range_query(&population[ind], population);
+            if neighbors.len() < self.c_capacity {
+                continue;
+            }
+
+            new_cluster = true;
+            self.c[ind] = Classification::Core(cluster);
+
+            for n_idx in neighbors {
+                // n_idx is at least an edge point
+                if self.c[n_idx] == Classification::Noise {
+                    self.c[n_idx] = Classification::Edge(cluster);
+                }
+
+                if self.v[n_idx] {
+                    continue;
+                }
+
+                self.v[n_idx] = true;
+                queue.push(n_idx);
+            }
+        }
+        new_cluster
+    }
+
+    pub fn cluster(mut self, population: Vec<T>, zoom: u8) -> Result<Cluster<N, P, T>, GeoError> {
+        self.c = vec![Classification::Noise; population.len()];
+        self.v = vec![false; population.len()];
+
+        let mut cluster = 0;
+        let mut queue = Vec::new();
+
+        for idx in 0..population.len() {
+            if self.v[idx] {
+                continue;
+            }
+
+            self.v[idx] = true;
+
+            queue.push(idx);
+
+            if self.expand_cluster(population.as_slice(), &mut queue, cluster) {
+                cluster += 1;
+            }
+        }
+
+        let points = self.c
+            .iter()
+            .zip(population)
+            .map(|(p, c)| match p {
+                Classification::Core(id) => (*id as u32 + 1, c),
+                _ => (0, c),
+            })
+            .collect();
+
+        Cluster::try_from((points, zoom))
+    }
+}

--- a/src/geo/coord/latlng.rs
+++ b/src/geo/coord/latlng.rs
@@ -2,6 +2,8 @@ use std::fmt::{Debug, Formatter};
 use crate::geo::error::GeoError;
 
 use crate::codec::osm::{PrimitiveBlock};
+use crate::geo::{Project, SRID3857_MAX_LNG};
+use crate::geo::project::SlippyTile;
 #[cfg(feature="grpc_server")]
 use crate::server::route::router_service::Coordinate;
 
@@ -98,6 +100,17 @@ impl LatLng {
 
     pub fn expand(&self) -> (Degree, Degree) {
         (self.lat(), self.lng())
+    }
+
+    pub fn slice(&self) -> [Degree; 2] {
+        [self.lat(), self.lng()]
+    }
+
+    pub fn hash(&self, zoom: u8) -> u32 {
+        let SlippyTile((_, px), (_, py), zoom) = SlippyTile::project(self, zoom);
+
+        let hash_size = (SRID3857_MAX_LNG / 2) / 2_u32.pow(zoom as u32);
+        hash_size * ((SRID3857_MAX_LNG + px) / hash_size) + ((SRID3857_MAX_LNG + py) / hash_size)
     }
 
     /// Offsets the `LatLng` from the given parent primitive.

--- a/src/geo/coord/latlng.rs
+++ b/src/geo/coord/latlng.rs
@@ -102,8 +102,9 @@ impl LatLng {
         (self.lat(), self.lng())
     }
 
+    // Returns a [`lng`, `lat`] pair
     pub fn slice(&self) -> [Degree; 2] {
-        [self.lat(), self.lng()]
+        [self.lng(), self.lat()]
     }
 
     pub fn hash(&self, zoom: u8) -> u32 {

--- a/src/geo/coord/point.rs
+++ b/src/geo/coord/point.rs
@@ -2,7 +2,7 @@ use crate::geo::coord::latlng::LatLng;
 
 /// A generic trait used for tiling a point
 /// using the `MVT` schema.
-pub trait Point<T, const N: usize> {
+pub trait TileItem<T, const N: usize> {
     /// Returns the identifier of the location pointed to.
     /// This has different representative meaning, according
     /// to where it is located, and what it represents.
@@ -19,7 +19,7 @@ pub trait Point<T, const N: usize> {
     fn values(&self) -> [T; N];
 }
 
-impl Point<(), 0> for LatLng {
+impl TileItem<(), 0> for LatLng {
     fn id(&self) -> u64 {
         todo!()
     }

--- a/src/geo/coord/point.rs
+++ b/src/geo/coord/point.rs
@@ -18,3 +18,21 @@ pub trait Point<T, const N: usize> {
     /// Outputs the sized `T` array of values
     fn values(&self) -> [T; N];
 }
+
+impl Point<(), 0> for LatLng {
+    fn id(&self) -> u64 {
+        todo!()
+    }
+
+    fn lat_lng(&self) -> LatLng {
+        self.clone()
+    }
+
+    fn keys<'a>() -> [&'a str; 0] {
+        todo!()
+    }
+
+    fn values(&self) -> [(); 0] {
+        todo!()
+    }
+}

--- a/src/geo/mod.rs
+++ b/src/geo/mod.rs
@@ -16,6 +16,6 @@ pub mod cluster;
 #[doc(inline)]
 pub use coord::latlng::LatLng;
 #[doc(inline)]
-pub use coord::point::Point;
+pub use coord::point::TileItem;
 #[doc(inline)]
 pub use project::Project;

--- a/src/geo/mod.rs
+++ b/src/geo/mod.rs
@@ -3,11 +3,15 @@
 pub const MVT_EXTENT: u32 = 4096;
 pub const MVT_VERSION: u32 = 2;
 
+const MEAN_EARTH_RADIUS: f64 = 6371008.8;
+const SRID3857_MAX_LNG: u32 = 20026377;
+
 #[doc(hidden)]
 pub mod coord;
 #[doc(hidden)]
 pub mod error;
 pub mod project;
+pub mod cluster;
 
 #[doc(inline)]
 pub use coord::latlng::LatLng;

--- a/src/geo/project.rs
+++ b/src/geo/project.rs
@@ -1,6 +1,6 @@
 //! Required structures to project between standards
 
-use crate::geo::coord::point::Point;
+use crate::geo::coord::point::TileItem;
 
 /// Allows for projection between two standards.
 pub trait Project {
@@ -16,7 +16,7 @@ pub trait Project {
     /// let SlippyTile((x, px), (y, py), z) = SlippyTile::project(&value, 19);
     /// // We now have the slippy tile coordinate of the original lat/lng.
     /// ```
-    fn project<G, T, const N: usize>(value: &T, zoom: u8) -> Self where T: Point<G, N>;
+    fn project<G, T, const N: usize>(value: &T, zoom: u8) -> Self where T: TileItem<G, N>;
 }
 
 #[doc(hidden)]
@@ -52,7 +52,7 @@ impl Project for SlippyTile {
     /// See the [OSM Wiki](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Mathematics) for the projection source.
     fn project<G, T, const N: usize>(value: &T, zoom: u8) -> Self
     where
-        T: Point<G, N>,
+        T: TileItem<G, N>,
     {
         let offset = |value: f64| {
             let n = value.floor() as u32;
@@ -81,7 +81,7 @@ impl Project for SlippyTile {
 impl Project for WebMercator {
     fn project<G, T, const N: usize>(value: &T, _: u8) -> Self
     where
-        T: Point<G, N>,
+        T: TileItem<G, N>,
     {
         WebMercator(value.lat_lng())
     }

--- a/src/tile/datasource/date.rs
+++ b/src/tile/datasource/date.rs
@@ -1,24 +1,43 @@
-use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
+use log::error;
 use serde::{de, Deserialize, Deserializer};
 
 const STORAGE_FORMAT: &str = "%y%m%d";
 const REQUEST_FORMAT: &str = "%Y-%m-%d";
 
-pub struct DateRange(pub DateTime<Utc>, pub DateTime<Utc>);
+#[derive(Copy, Clone, Debug)]
+pub struct UtcDate(pub DateTime<Utc>);
+
+impl PartialOrd for UtcDate {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl PartialEq for UtcDate {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
 
 pub fn format_date(date: &DateTime<Utc>) -> String {
     return date.format(STORAGE_FORMAT).to_string();
 }
 
-pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    match String::deserialize(deserializer) {
-        Err(err) => Err(err),
-        Ok(date) => match NaiveDateTime::parse_from_str(&date, REQUEST_FORMAT) {
-            Err(err) => Err(de::Error::custom(err.to_string())),
-            Ok(date) => Ok(Utc.from_utc_datetime(&date)),
-        },
+impl<'de> Deserialize<'de> for UtcDate {
+    fn deserialize<D>(deserializer: D) -> Result<UtcDate, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match String::deserialize(deserializer) {
+            Err(err) => Err(err),
+            Ok(date) => match NaiveDate::parse_from_str(&date, REQUEST_FORMAT) {
+                Err(err) => {
+                    error!("{}", err);
+                    Err(de::Error::custom(err.to_string()))
+                },
+                Ok(date) => Ok(UtcDate(Utc.from_utc_datetime(&NaiveDateTime::from(date)))),
+            },
+        }
     }
 }

--- a/src/tile/error.rs
+++ b/src/tile/error.rs
@@ -17,14 +17,14 @@ pub enum TileError {
     NoMatchingRepository
 }
 
-impl IntoResponse for TileError {
+impl IntoResponse for crate::Error {
     fn into_response(self) -> Response {
         #[cfg(feature = "tracing")]
         event!(Level::ERROR, name=?self);
 
         let code = match self {
-            TileError::NoTilesFound => StatusCode::NO_CONTENT,
-            TileError::NoMatchingRepository => StatusCode::NOT_FOUND,
+            crate::Error::Tile(TileError::NoTilesFound) => StatusCode::NO_CONTENT,
+            crate::Error::Tile(TileError::NoMatchingRepository) => StatusCode::NOT_FOUND,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
 

--- a/src/tile/mod.rs
+++ b/src/tile/mod.rs
@@ -5,6 +5,7 @@ pub mod repositories;
 pub mod fragment;
 pub mod layer;
 
+
 #[doc(hidden)]
 pub mod mvt;
 #[doc(hidden)]


### PR DESCRIPTION
### Changes
- Implement `Cluster`
- Renamed `Point` to `TileItem` (More domain-specific)
- Deprecated `DateRange`, added `UtcDate` wrapper for custom-deserialisation
- Created `IntoCluster` to create a `Cluster` from `Vec<T: TileItem>`.
- Coppied `haversine_distance` from formula.