### PR TITLE
mod: `mimalloc` as default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ name = "codec_target"
 harness = false
 
 [features]
-default = ["codec", "route"]
+default = ["codec", "route", "mimalloc"]
 
 tracing = ["dep:tracing", "tracing-subscriber", "opentelemetry", "opentelemetry_sdk", "tracing-opentelemetry", "opentelemetry-otlp"]
 


### PR DESCRIPTION
Enables the `mimalloc` feature by default, users can opt-out, in cases where from-c compilation is not possible, by passing `--no-default-features`.