### PR TITLE
feat: Upper-Bounded Map-Matching Search Heuristic

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[profile.profiling]
+inherits = "release"
+debug = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "dotenv",
  "either",
+ "env_logger",
  "fast_hilbert",
  "flate2",
  "geo",
@@ -23,9 +24,11 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "osmpbf",
+ "pathfinding",
  "petgraph",
  "prost",
  "prost-build",
+ "quick-protobuf",
  "rayon",
  "rstar",
  "scc",
@@ -569,6 +572,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "deprecate-until"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3767f826efbbe5a5ae093920b58b43b01734202be697e1354914e862e8e704"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "semver",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
 dependencies = [
  "log",
+ "regex",
 ]
 
 [[package]]
@@ -608,6 +624,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
+ "humantime",
  "log",
 ]
 
@@ -975,6 +992,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1137,15 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
  "rayon",
+]
+
+[[package]]
+name = "integer-sqrt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1430,6 +1462,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "pathfinding"
+version = "4.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cff69f3ba9d0346c1dbe1248fc2ed4523567b683d1b6ff4144a6b3583369082"
+dependencies = [
+ "deprecate-until",
+ "indexmap 2.2.6",
+ "integer-sqrt",
+ "num-traits",
+ "rustc-hash",
+ "thiserror",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "3.4.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58678a64de2fced2bdec6bca052a6716a0efe692d6e3f53d1bda6a1def64cfc0"
+checksum = "a3a7c64d9bf75b1b8d981124c14c179074e8caa7dfe7b6a12e6222ddcd0c8f72"
 dependencies = [
  "once_cell",
  "protobuf-support",
@@ -1649,9 +1695,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-codegen"
-version = "3.4.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32777b0b3f6538d9d2e012b3fad85c7e4b9244b5958d04a6415f4333782b7a77"
+checksum = "e26b833f144769a30e04b1db0146b2aaa53fd2fd83acf10a6b5f996606c18144"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -1664,12 +1710,12 @@ dependencies = [
 
 [[package]]
 name = "protobuf-parse"
-version = "3.4.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cb37955261126624a25b5e6bda40ae34cf3989d52a783087ca6091b29b5642"
+checksum = "322330e133eab455718444b4e033ebfac7c6528972c784fcde28d2cc783c6257"
 dependencies = [
  "anyhow",
- "indexmap 1.9.3",
+ "indexmap 2.2.6",
  "log",
  "protobuf",
  "protobuf-support",
@@ -1680,11 +1726,20 @@ dependencies = [
 
 [[package]]
 name = "protobuf-support"
-version = "3.4.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ed294a835b0f30810e13616b1cd34943c6d1e84a8f3b0dcfe466d256c3e7e7"
+checksum = "b088fd20b938a875ea00843b6faf48579462630015c3788d397ad6a786663252"
 dependencies = [
  "thiserror",
+]
+
+[[package]]
+name = "quick-protobuf"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1830,6 +1885,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,6 +2025,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "osmpbf",
+ "parking_lot",
  "pathfinding",
  "petgraph",
  "prost",
@@ -1243,6 +1244,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,6 +1471,32 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "libc",
+ "petgraph",
+ "redox_syscall",
+ "smallvec",
+ "thread-id",
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "pathfinding"
@@ -1802,6 +1839,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1996,6 +2042,12 @@ checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
@@ -2276,6 +2328,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "thread-id"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,8 @@ dependencies = [
  "codspeed",
  "colored",
  "criterion",
+ "futures",
+ "tokio",
 ]
 
 [[package]]
@@ -508,6 +510,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
+ "futures",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -520,6 +523,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -677,12 +681,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -701,6 +720,12 @@ dependencies = [
  "futures-task",
  "futures-util",
 ]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -2208,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,10 @@ harness = false
 name = "codec_target"
 harness = false
 
+[[bench]]
+name = "total_ingestion"
+harness = false
+
 [features]
 default = ["codec", "route", "mimalloc"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ tonic-web = {  version = "0.12.3", optional = true }
 
 bytes = { version = "1.8.0", features = ["default"] } # Required for io::Cursor
 prost = { version = "0.13.3"}
-tokio = { version = "1.41.0", features = ["rt", "rt-multi-thread", "macros"], optional = true }
+tokio = { version = "1.41.1", features = ["rt", "rt-multi-thread", "macros", "fs"], optional = true }
 
 # HTTP Server Dependencies [Optional-"http_server"]
 tower-http = { version = "0.6.1", features = ["cors"], optional = true }
@@ -77,7 +77,7 @@ prost-build = { version = "0.13.3"}
 
 [dev-dependencies]
 osmpbf = { version = "0.3.4", features = ["zlib-ng"], default-features = false }
-criterion = { version = "2.7.2", package = "codspeed-criterion-compat" }
+criterion = { version = "2.7.2", features = ["async_tokio"], package = "codspeed-criterion-compat" }
 
 [[bench]]
 name = "codec_sweep"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,16 @@ test-log = { version = "0.2.16", features = ["log"] }
 # gRPC Server Dependencies [Optional-"grpc_server"]
 tonic = { version = "0.12.3", features = ["tls", "tls-roots"], optional = true }
 tonic-reflection = { version = "0.12.3", optional = true }
-tonic-web = {  version = "0.12.3", optional = true }
+tonic-web = { version = "0.12.3", optional = true }
 
 bytes = { version = "1.8.0", features = ["default"] } # Required for io::Cursor
-prost = { version = "0.13.3"}
-tokio = { version = "1.41.1", features = ["rt", "rt-multi-thread", "macros", "fs"], optional = true }
+prost = { version = "0.13.3" }
+tokio = { version = "1.41.1", features = [
+    "rt",
+    "rt-multi-thread",
+    "macros",
+    "fs",
+], optional = true }
 
 # HTTP Server Dependencies [Optional-"http_server"]
 tower-http = { version = "0.6.1", features = ["cors"], optional = true }
@@ -52,10 +57,16 @@ serde_qs = { version = "0.13.0", optional = true }
 
 # Tracing [Optional-"tracing"]
 tracing = { version = "0.1.40", optional = true }
-tracing-subscriber = { version = "0.3.18", features = ["tracing-log", "fmt", "env-filter"], optional = true }
+tracing-subscriber = { version = "0.3.18", features = [
+    "tracing-log",
+    "fmt",
+    "env-filter",
+], optional = true }
 opentelemetry = { version = "0.26.0", optional = true }
-opentelemetry_sdk = { version = "0.26.0", features = ["rt-tokio"], optional = true }
-tracing-opentelemetry = {  version = "0.27.0", optional = true }
+opentelemetry_sdk = { version = "0.26.0", features = [
+    "rt-tokio",
+], optional = true }
+tracing-opentelemetry = { version = "0.27.0", optional = true }
 opentelemetry-otlp = { version = "0.26.0", features = ["tls"], optional = true }
 
 # Optimisations and Compression
@@ -63,21 +74,26 @@ rayon = "1.10.0"
 either = "1.13.0"
 chrono = "0.4.38"
 flate2 = { version = "1.0.34", features = ["zlib-ng"], optional = true }
-fast_hilbert = {  version = "2.0.0", optional = true }
+fast_hilbert = { version = "2.0.0", optional = true }
 scc = { version = "2.2.4", optional = true }
 geo = "0.29.1"
 wkt = "0.11.1"
 mimalloc = { version = "0.1.43", optional = true }
 geohash = "0.13.1"
 strum = { version = "0.26.3", features = ["phf", "derive"] }
+quick-protobuf = "0.8.1"
+env_logger = "0.11.5"
+pathfinding = "4.11.0"
 
 [build-dependencies]
 tonic-build = { version = "0.12.3", features = ["prost"] }
-prost-build = { version = "0.13.3"}
+prost-build = { version = "0.13.3" }
 
 [dev-dependencies]
 osmpbf = { version = "0.3.4", features = ["zlib-ng"], default-features = false }
-criterion = { version = "2.7.2", features = ["async_tokio"], package = "codspeed-criterion-compat" }
+criterion = { version = "2.7.2", features = [
+    "async_tokio",
+], package = "codspeed-criterion-compat" }
 
 [[bench]]
 name = "codec_sweep"
@@ -94,7 +110,14 @@ harness = false
 [features]
 default = ["codec", "route", "mimalloc"]
 
-tracing = ["dep:tracing", "tracing-subscriber", "opentelemetry", "opentelemetry_sdk", "tracing-opentelemetry", "opentelemetry-otlp"]
+tracing = [
+    "dep:tracing",
+    "tracing-subscriber",
+    "opentelemetry",
+    "opentelemetry_sdk",
+    "tracing-opentelemetry",
+    "opentelemetry-otlp",
+]
 
 grpc_server = ["tonic", "tonic-reflection", "tonic-web", "tower-http", "tokio"]
 http_server = ["tower-http", "axum", "axum-macros", "serde_qs", "tokio"]
@@ -117,6 +140,6 @@ opt-level = 3
 lto = true
 
 [[example]]
-name = "Route Client"
+name = "RouteClient"
 path = "examples/route_client.rs"
 required-features = ["grpc_server"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ strum = { version = "0.26.3", features = ["phf", "derive"] }
 quick-protobuf = "0.8.1"
 env_logger = "0.11.5"
 pathfinding = "4.11.0"
+parking_lot = { version = "0.12.3", features = ["deadlock_detection"] }
 
 [build-dependencies]
 tonic-build = { version = "0.12.3", features = ["prost"] }

--- a/benches/codec_sweep.rs
+++ b/benches/codec_sweep.rs
@@ -6,8 +6,6 @@ use log::info;
 use rayon::iter::ParallelIterator;
 use std::any::Any;
 use std::path::PathBuf;
-use tokio::runtime::{Handle, Runtime};
-use tokio::task::spawn_blocking;
 
 fn block_iter_count() {
     let path = PathBuf::from(DISTRICT_OF_COLUMBIA);

--- a/benches/codec_sweep.rs
+++ b/benches/codec_sweep.rs
@@ -9,22 +9,18 @@ use std::path::PathBuf;
 use tokio::runtime::{Handle, Runtime};
 use tokio::task::spawn_blocking;
 
-async fn block_iter_count() {
+fn block_iter_count() {
     let path = PathBuf::from(DISTRICT_OF_COLUMBIA);
-    let mut iter = BlockIterator::new(path)
-        .await
-        .expect("Could not create iterator");
+    let mut iter = BlockIterator::new(path).expect("Could not create iterator");
 
     iter.par_iter().for_each(|item| {
         info!("Block: {:?}", item.type_id());
     });
 }
 
-async fn element_iter_count() {
+fn element_iter_count() {
     let path = PathBuf::from(DISTRICT_OF_COLUMBIA);
-    let iter = ElementIterator::new(path)
-        .await
-        .expect("Could not create iterator");
+    let iter = ElementIterator::new(path).expect("Could not create iterator");
 
     let nodes = iter.map_red(
         |item| match item {
@@ -40,11 +36,9 @@ async fn element_iter_count() {
     info!("There are {nodes} nodes");
 }
 
-async fn processed_iter_count() {
+fn processed_iter_count() {
     let path = PathBuf::from(DISTRICT_OF_COLUMBIA);
-    let iter = ProcessedElementIterator::new(path)
-        .await
-        .expect("Could not create iterator");
+    let iter = ProcessedElementIterator::new(path).expect("Could not create iterator");
 
     let nodes = iter.map_red(
         |item| match item {
@@ -62,17 +56,10 @@ fn sweep_benchmark(c: &mut criterion::Criterion) {
     let mut group = c.benchmark_group("iterator_sweep");
     group.significance_level(0.1).sample_size(30);
 
-    group.bench_function("block_iter_count", |b| {
-        b.to_async(Runtime::new().expect("Must have runtime"))
-            .iter(|| block_iter_count())
-    });
-    group.bench_function("element_iter_count", |b| {
-        b.to_async(Runtime::new().expect("Must have runtime"))
-            .iter(|| element_iter_count())
-    });
+    group.bench_function("block_iter_count", |b| b.iter(|| block_iter_count()));
+    group.bench_function("element_iter_count", |b| b.iter(|| element_iter_count()));
     group.bench_function("processed_iter_count", |b| {
-        b.to_async(Runtime::new().expect("Must have runtime"))
-            .iter(|| processed_iter_count())
+        b.iter(|| processed_iter_count())
     });
     group.finish();
 }

--- a/benches/codec_target.rs
+++ b/benches/codec_target.rs
@@ -2,9 +2,8 @@ use aaru::codec::consts::DISTRICT_OF_COLUMBIA;
 use aaru::codec::{BlockItem, BlockIterator};
 use criterion::criterion_main;
 use log::error;
-use rayon::iter::{ParallelBridge, ParallelIterator};
+use rayon::iter::ParallelIterator;
 use std::path::PathBuf;
-use tokio::runtime::Runtime;
 
 fn iterate_blocks_each() {
     let path = PathBuf::from(DISTRICT_OF_COLUMBIA);

--- a/benches/codec_target.rs
+++ b/benches/codec_target.rs
@@ -37,11 +37,10 @@ async fn iterate_blocks_each() {
 async fn parallel_iterate_blocks_each() {
     let path = PathBuf::from(DISTRICT_OF_COLUMBIA);
 
-    let block_iter = BlockIterator::new(path).await.unwrap();
+    let mut block_iter = BlockIterator::new(path).await.unwrap();
 
     let elements = block_iter
-        .into_iter()
-        .par_bridge()
+        .par_iter()
         .map(|block| match block {
             BlockItem::HeaderBlock(_) => (0, 1),
             BlockItem::PrimitiveBlock(_) => (1, 0),

--- a/benches/codec_target.rs
+++ b/benches/codec_target.rs
@@ -6,9 +6,9 @@ use rayon::iter::{ParallelBridge, ParallelIterator};
 use std::path::PathBuf;
 use tokio::runtime::Runtime;
 
-async fn iterate_blocks_each() {
+fn iterate_blocks_each() {
     let path = PathBuf::from(DISTRICT_OF_COLUMBIA);
-    let iterator = BlockIterator::new(path.clone()).await;
+    let iterator = BlockIterator::new(path.clone());
 
     let mut primitive_blocks = 0;
     let mut header_blocks = 0;
@@ -34,10 +34,10 @@ async fn iterate_blocks_each() {
     assert_eq!(primitive_blocks, 237);
 }
 
-async fn parallel_iterate_blocks_each() {
+fn parallel_iterate_blocks_each() {
     let path = PathBuf::from(DISTRICT_OF_COLUMBIA);
 
-    let mut block_iter = BlockIterator::new(path).await.unwrap();
+    let mut block_iter = BlockIterator::new(path).unwrap();
 
     let elements = block_iter
         .par_iter()
@@ -86,13 +86,9 @@ fn target_benchmark(c: &mut criterion::Criterion) {
     let mut group = c.benchmark_group("iterator_target");
     group.significance_level(0.1).sample_size(30);
 
-    group.bench_function("iterate_blocks_each", |b| {
-        b.to_async(Runtime::new().expect("Must have runtime"))
-            .iter(|| iterate_blocks_each())
-    });
+    group.bench_function("iterate_blocks_each", |b| b.iter(|| iterate_blocks_each()));
     group.bench_function("parallel_iterate_blocks_each", |b| {
-        b.to_async(Runtime::new().expect("Must have runtime"))
-            .iter(|| parallel_iterate_blocks_each())
+        b.iter(|| parallel_iterate_blocks_each())
     });
     group.bench_function("compared_to_osmpbf", |b| b.iter(|| compare_to_osmpbf()));
 

--- a/benches/total_ingestion.rs
+++ b/benches/total_ingestion.rs
@@ -1,0 +1,59 @@
+use aaru::codec::consts::DISTRICT_OF_COLUMBIA;
+use aaru::codec::element::ProcessedElement;
+use aaru::codec::{Element, ElementIterator, Parallel, ProcessedElementIterator};
+
+use criterion::criterion_main;
+use log::info;
+
+use aaru::route::Graph;
+use std::path::{Path, PathBuf};
+use tokio::runtime::Runtime;
+use tokio::time::Instant;
+
+async fn ingest_and_count() {
+    let timer = Instant::now();
+    let path = PathBuf::from(Path::new(DISTRICT_OF_COLUMBIA));
+    let reader = ProcessedElementIterator::new(path).await.expect("!");
+
+    let (ways, nodes) = reader.par_red(
+        |(ways, nodes), element| match element {
+            ProcessedElement::Way(_) => (ways + 1, nodes),
+            ProcessedElement::Node(_) => (ways, nodes + 1),
+        },
+        |(ways, nodes), (ways2, nodes2)| (ways + ways2, nodes + nodes2),
+        || (0u64, 0u64),
+    );
+
+    info!(
+        "Got {} ways and {} nodes in {}ms",
+        ways,
+        nodes,
+        timer.elapsed().as_millis()
+    );
+}
+
+async fn ingest_as_full_graph() {
+    let path = Path::new(DISTRICT_OF_COLUMBIA)
+        .as_os_str()
+        .to_ascii_lowercase();
+    let graph = Graph::new(path).await.expect("Could not generate graph");
+    info!("Graph generated, size: {}", graph.size());
+}
+
+fn ingestion_benchmark(c: &mut criterion::Criterion) {
+    let mut group = c.benchmark_group("ingestion_benchmark");
+    group.significance_level(0.1).sample_size(30);
+
+    group.bench_function("ingest_and_count", |b| {
+        b.to_async(Runtime::new().expect("Must have runtime"))
+            .iter(|| ingest_and_count())
+    });
+    group.bench_function("ingest_as_full_graph", |b| {
+        b.to_async(Runtime::new().expect("Must have runtime"))
+            .iter(|| ingest_as_full_graph())
+    });
+    group.finish();
+}
+
+criterion::criterion_group!(standard_benches, ingestion_benchmark);
+criterion_main!(standard_benches);

--- a/benches/total_ingestion.rs
+++ b/benches/total_ingestion.rs
@@ -1,13 +1,12 @@
 use aaru::codec::consts::DISTRICT_OF_COLUMBIA;
 use aaru::codec::element::ProcessedElement;
-use aaru::codec::{Element, ElementIterator, Parallel, ProcessedElementIterator};
+use aaru::codec::{Parallel, ProcessedElementIterator};
 
 use criterion::criterion_main;
 use log::info;
 
 use aaru::route::Graph;
 use std::path::{Path, PathBuf};
-use tokio::runtime::Runtime;
 use tokio::time::Instant;
 
 fn ingest_and_count() {

--- a/benches/total_ingestion.rs
+++ b/benches/total_ingestion.rs
@@ -10,10 +10,10 @@ use std::path::{Path, PathBuf};
 use tokio::runtime::Runtime;
 use tokio::time::Instant;
 
-async fn ingest_and_count() {
+fn ingest_and_count() {
     let timer = Instant::now();
     let path = PathBuf::from(Path::new(DISTRICT_OF_COLUMBIA));
-    let reader = ProcessedElementIterator::new(path).await.expect("!");
+    let reader = ProcessedElementIterator::new(path).expect("!");
 
     let (ways, nodes) = reader.par_red(
         |(ways, nodes), element| match element {
@@ -32,11 +32,11 @@ async fn ingest_and_count() {
     );
 }
 
-async fn ingest_as_full_graph() {
+fn ingest_as_full_graph() {
     let path = Path::new(DISTRICT_OF_COLUMBIA)
         .as_os_str()
         .to_ascii_lowercase();
-    let graph = Graph::new(path).await.expect("Could not generate graph");
+    let graph = Graph::new(path).expect("Could not generate graph");
     info!("Graph generated, size: {}", graph.size());
 }
 
@@ -44,13 +44,9 @@ fn ingestion_benchmark(c: &mut criterion::Criterion) {
     let mut group = c.benchmark_group("ingestion_benchmark");
     group.significance_level(0.1).sample_size(30);
 
-    group.bench_function("ingest_and_count", |b| {
-        b.to_async(Runtime::new().expect("Must have runtime"))
-            .iter(|| ingest_and_count())
-    });
+    group.bench_function("ingest_and_count", |b| b.iter(|| ingest_and_count()));
     group.bench_function("ingest_as_full_graph", |b| {
-        b.to_async(Runtime::new().expect("Must have runtime"))
-            .iter(|| ingest_as_full_graph())
+        b.iter(|| ingest_as_full_graph())
     });
     group.finish();
 }

--- a/examples/route.rs
+++ b/examples/route.rs
@@ -1,7 +1,13 @@
 use aaru::codec::consts::SYDNEY;
+use aaru::codec::element::ProcessedElement;
+use aaru::codec::parallel::Parallel;
+use aaru::codec::ProcessedElementIterator;
 use aaru::server::route::router_service::router_service_server::RouterServiceServer;
 use aaru::server::route::{router_service, RouteService};
 use dotenv::dotenv;
+use log::info;
+use std::path::{Path, PathBuf};
+use tokio::time::Instant;
 use tonic::codegen::http::Method;
 use tonic::transport::Server;
 use tonic_web::GrpcWebLayer;
@@ -19,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create the router
     #[cfg(feature = "tracing")]
     tracing::info!("Creating Router");
-    let router = RouteService::from_file(SYDNEY).expect("-").await;
+    let router = RouteService::from_file(SYDNEY).await.expect("-");
 
     #[cfg(feature = "tracing")]
     tracing::info!("Router Created");

--- a/examples/route.rs
+++ b/examples/route.rs
@@ -1,13 +1,8 @@
 use aaru::codec::consts::SYDNEY;
-use aaru::codec::element::ProcessedElement;
-use aaru::codec::parallel::Parallel;
-use aaru::codec::ProcessedElementIterator;
 use aaru::server::route::router_service::router_service_server::RouterServiceServer;
 use aaru::server::route::{router_service, RouteService};
+
 use dotenv::dotenv;
-use log::info;
-use std::path::{Path, PathBuf};
-use tokio::time::Instant;
 use tonic::codegen::http::Method;
 use tonic::transport::Server;
 use tonic_web::GrpcWebLayer;

--- a/examples/route.rs
+++ b/examples/route.rs
@@ -1,4 +1,4 @@
-use aaru::codec::consts::SYDNEY;
+use aaru::codec::consts::AUSTRALIA;
 use aaru::server::route::router_service::router_service_server::RouterServiceServer;
 use aaru::server::route::{router_service, RouteService};
 
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create the router
     #[cfg(feature = "tracing")]
     tracing::info!("Creating Router");
-    let router = RouteService::from_file(SYDNEY).expect("-");
+    let router = RouteService::from_file(AUSTRALIA).expect("-");
 
     #[cfg(feature = "tracing")]
     tracing::info!("Router Created");

--- a/examples/route.rs
+++ b/examples/route.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create the router
     #[cfg(feature = "tracing")]
     tracing::info!("Creating Router");
-    let router = RouteService::from_file(SYDNEY).await.expect("-");
+    let router = RouteService::from_file(SYDNEY).expect("-");
 
     #[cfg(feature = "tracing")]
     tracing::info!("Router Created");

--- a/examples/route.rs
+++ b/examples/route.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create the router
     #[cfg(feature = "tracing")]
     tracing::info!("Creating Router");
-    let router = RouteService::from_file(SYDNEY).expect("-");
+    let router = RouteService::from_file(SYDNEY).expect("-").await;
 
     #[cfg(feature = "tracing")]
     tracing::info!("Router Created");

--- a/examples/route_client.rs
+++ b/examples/route_client.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             latitude: -33.850842,
             longitude: 151.210193,
         }),
-        quantity: 5,
+        search_radius: 100.0,
     });
 
     let start = Instant::now();

--- a/proto/aaru/v1/aaru.proto
+++ b/proto/aaru/v1/aaru.proto
@@ -47,7 +47,7 @@ message RouteResponse {
 // Specifies the distance and a position from which to search
 message ClosestSnappedPointRequest {
   Coordinate point = 1;
-  uint32 quantity = 2;
+  double search_radius = 2;
 }
 
 message ClosestPointRequest {

--- a/src/codec/blob/iterator.rs
+++ b/src/codec/blob/iterator.rs
@@ -7,11 +7,11 @@ use crate::codec::BlockItem;
 
 use log::trace;
 use prost::Message;
+use std::fs::File;
+use std::io;
+use std::io::{BufReader, Read};
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::fs::File;
-use tokio::io;
-use tokio::io::{AsyncReadExt, BufReader};
 
 const HEADER_LEN_SIZE: usize = 4;
 
@@ -23,12 +23,12 @@ pub struct BlobIterator {
 }
 
 impl BlobIterator {
-    pub async fn new(path: PathBuf) -> Result<BlobIterator, io::Error> {
-        let file = File::open(path).await?;
+    pub fn new(path: PathBuf) -> Result<BlobIterator, io::Error> {
+        let file = File::open(path)?;
 
         let mut buf = Vec::new(); // vec![0; file.metadata()?.size() as usize];
         let mut reader = BufReader::new(file);
-        reader.read_to_end(&mut buf).await?;
+        reader.read_to_end(&mut buf)?;
         let buf = Arc::new(buf);
 
         Ok(BlobIterator {

--- a/src/codec/blob/iterator.rs
+++ b/src/codec/blob/iterator.rs
@@ -4,12 +4,14 @@
 use crate::codec::blob::item::BlobItem;
 use crate::codec::osm::BlobHeader;
 use crate::codec::BlockItem;
+
 use log::trace;
 use prost::Message;
-use std::fs::File;
-use std::io::{self, BufReader, Read};
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::fs::File;
+use tokio::io;
+use tokio::io::{AsyncReadExt, BufReader};
 
 const HEADER_LEN_SIZE: usize = 4;
 
@@ -21,12 +23,12 @@ pub struct BlobIterator {
 }
 
 impl BlobIterator {
-    pub fn new(path: PathBuf) -> Result<BlobIterator, io::Error> {
-        let file = File::open(path)?;
+    pub async fn new(path: PathBuf) -> Result<BlobIterator, io::Error> {
+        let file = File::open(path).await?;
 
         let mut buf = Vec::new(); // vec![0; file.metadata()?.size() as usize];
         let mut reader = BufReader::new(file);
-        reader.read_to_end(&mut buf)?;
+        reader.read_to_end(&mut buf).await?;
         let buf = Arc::new(buf);
 
         Ok(BlobIterator {

--- a/src/codec/block/iterator.rs
+++ b/src/codec/block/iterator.rs
@@ -5,11 +5,11 @@ use crate::codec::block::item::BlockItem;
 use crate::codec::BlobItem;
 
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use std::fs::File;
+use std::io;
+use std::io::{BufReader, Read};
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::fs::File;
-use tokio::io;
-use tokio::io::{AsyncReadExt, BufReader};
 
 pub struct BlockIterator {
     blobs: Vec<BlobItem>,
@@ -19,12 +19,12 @@ pub struct BlockIterator {
 
 impl BlockIterator {
     #[inline]
-    pub async fn new(path: PathBuf) -> Result<BlockIterator, io::Error> {
-        let file = File::open(path).await?;
+    pub fn new(path: PathBuf) -> Result<BlockIterator, io::Error> {
+        let file = File::open(path)?;
 
         let mut buf = Vec::new();
         let mut reader = BufReader::new(file);
-        reader.read_to_end(&mut buf).await?;
+        reader.read_to_end(&mut buf)?;
 
         let buf = Arc::new(buf);
 

--- a/src/codec/block/iterator.rs
+++ b/src/codec/block/iterator.rs
@@ -3,12 +3,13 @@
 use crate::codec::blob::iterator::BlobIterator;
 use crate::codec::block::item::BlockItem;
 use crate::codec::BlobItem;
+
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-use std::fs::File;
-use std::io;
-use std::io::{BufReader, Read};
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::fs::File;
+use tokio::io;
+use tokio::io::{AsyncReadExt, BufReader};
 
 pub struct BlockIterator {
     blobs: Vec<BlobItem>,
@@ -18,12 +19,12 @@ pub struct BlockIterator {
 
 impl BlockIterator {
     #[inline]
-    pub fn new(path: PathBuf) -> Result<BlockIterator, io::Error> {
-        let file = File::open(path)?;
+    pub async fn new(path: PathBuf) -> Result<BlockIterator, io::Error> {
+        let file = File::open(path).await?;
 
         let mut buf = Vec::new();
         let mut reader = BufReader::new(file);
-        reader.read_to_end(&mut buf)?;
+        reader.read_to_end(&mut buf).await?;
 
         let buf = Arc::new(buf);
 

--- a/src/codec/element/iterator.rs
+++ b/src/codec/element/iterator.rs
@@ -14,9 +14,9 @@ pub struct ElementIterator {
 }
 
 impl ElementIterator {
-    pub async fn new(path: PathBuf) -> Result<ElementIterator, CodecError> {
+    pub fn new(path: PathBuf) -> Result<ElementIterator, CodecError> {
         Ok(ElementIterator {
-            iter: BlockIterator::new(path).await?,
+            iter: BlockIterator::new(path)?,
         })
     }
 }

--- a/src/codec/element/iterator.rs
+++ b/src/codec/element/iterator.rs
@@ -14,9 +14,9 @@ pub struct ElementIterator {
 }
 
 impl ElementIterator {
-    pub fn new(path: PathBuf) -> Result<ElementIterator, CodecError> {
+    pub async fn new(path: PathBuf) -> Result<ElementIterator, CodecError> {
         Ok(ElementIterator {
-            iter: BlockIterator::new(path)?,
+            iter: BlockIterator::new(path).await?,
         })
     }
 }

--- a/src/codec/element/processed_iterator.rs
+++ b/src/codec/element/processed_iterator.rs
@@ -14,9 +14,9 @@ pub struct ProcessedElementIterator {
 }
 
 impl ProcessedElementIterator {
-    pub async fn new(path: PathBuf) -> Result<ProcessedElementIterator, CodecError> {
+    pub fn new(path: PathBuf) -> Result<ProcessedElementIterator, CodecError> {
         Ok(ProcessedElementIterator {
-            iter: BlockIterator::new(path).await?,
+            iter: BlockIterator::new(path)?,
         })
     }
 }

--- a/src/codec/element/processed_iterator.rs
+++ b/src/codec/element/processed_iterator.rs
@@ -14,9 +14,9 @@ pub struct ProcessedElementIterator {
 }
 
 impl ProcessedElementIterator {
-    pub fn new(path: PathBuf) -> Result<ProcessedElementIterator, CodecError> {
+    pub async fn new(path: PathBuf) -> Result<ProcessedElementIterator, CodecError> {
         Ok(ProcessedElementIterator {
-            iter: BlockIterator::new(path)?,
+            iter: BlockIterator::new(path).await?,
         })
     }
 }

--- a/src/codec/element/variants/node.rs
+++ b/src/codec/element/variants/node.rs
@@ -2,8 +2,7 @@
 //! of the context information required for changelogs, and utilising
 //! only the elements required for graph routing.
 
-use geo::{point, Destination, Distance, Euclidean, Geodesic, Haversine, Point};
-use rstar::primitives::CachedEnvelope;
+use geo::{point, Destination, Distance, Euclidean, Geodesic, Point};
 use rstar::{Envelope, AABB};
 use std::ops::{Add, Mul};
 

--- a/src/codec/element/variants/node.rs
+++ b/src/codec/element/variants/node.rs
@@ -2,7 +2,8 @@
 //! of the context information required for changelogs, and utilising
 //! only the elements required for graph routing.
 
-use geo::{point, Distance, Haversine, Point};
+use geo::{point, Destination, Distance, Euclidean, Geodesic, Haversine, Point};
+use rstar::primitives::CachedEnvelope;
 use rstar::{Envelope, AABB};
 use std::ops::{Add, Mul};
 
@@ -20,21 +21,21 @@ impl rstar::PointDistance for Node {
         &self,
         point: &<Self::Envelope as Envelope>::Point,
     ) -> <<Self::Envelope as Envelope>::Point as rstar::Point>::Scalar {
-        Haversine::distance(self.position, *point)
+        Euclidean::distance(self.position, *point).powi(2)
     }
 
-    fn distance_2_if_less_or_equal(
-        &self,
-        point: &<Self::Envelope as Envelope>::Point,
-        max_distance_2: <<Self::Envelope as Envelope>::Point as rstar::Point>::Scalar,
-    ) -> Option<<<Self::Envelope as Envelope>::Point as rstar::Point>::Scalar> {
-        // This should utilize Envelope optimisation
-        let distance = Haversine::distance(self.position, *point);
-        match distance < max_distance_2 {
-            true => Some(distance),
-            false => None,
-        }
-    }
+    // fn distance_2_if_less_or_equal(
+    //     &self,
+    //     point: &<Self::Envelope as Envelope>::Point,
+    //     max_distance_2: <<Self::Envelope as Envelope>::Point as rstar::Point>::Scalar,
+    // ) -> Option<<<Self::Envelope as Envelope>::Point as rstar::Point>::Scalar> {
+    //     // This should utilize Envelope optimisation
+    //     let distance = self.distance_2(point);
+    //     match distance <= max_distance_2 {
+    //         true => Some(distance),
+    //         false => None,
+    //     }
+    // }
 }
 
 impl rstar::RTreeObject for Node {
@@ -87,6 +88,12 @@ impl Node {
     /// Returns the identifier for the node
     pub fn id(&self) -> i64 {
         self.id
+    }
+
+    pub fn bounding(&self, distance: f64) -> AABB<Point> {
+        let bottom_right = Geodesic::destination(self.position, 135.0, distance);
+        let top_left = Geodesic::destination(self.position, 315.0, distance);
+        AABB::from_corners(top_left, bottom_right)
     }
 
     /// Takes an `osm::DenseNodes` structure and extracts `Node`s as an

--- a/src/codec/element/variants/way.rs
+++ b/src/codec/element/variants/way.rs
@@ -12,12 +12,17 @@ pub struct Way {
     #[allow(unused)]
     id: i64,
     road_tag: Option<String>,
+    one_way: bool,
     refs: Vec<i64>,
 }
 
 impl Way {
     pub fn is_road(&self) -> bool {
         self.road_tag.is_some()
+    }
+
+    pub fn is_one_way(&self) -> bool {
+        self.one_way
     }
 
     pub fn refs(&self) -> &Vec<i64> {
@@ -36,6 +41,7 @@ impl Way {
                 prior
             }),
             road_tag: value.road_tag(block),
+            one_way: value.one_way(block),
         }
     }
 }
@@ -65,6 +71,7 @@ const VALID_ROADWAYS: [&str; 12] = [
 ];
 
 impl osm::Way {
+    #[inline]
     pub fn road_tag(&self, block: &PrimitiveBlock) -> Option<String> {
         self.keys
             .iter()
@@ -77,5 +84,20 @@ impl osm::Way {
             })
             .find(|(key, value)| key == "highway" && VALID_ROADWAYS.contains(&value.as_str()))
             .map(|(_, value)| value)
+    }
+
+    #[inline]
+    pub fn one_way(&self, block: &PrimitiveBlock) -> bool {
+        self.keys
+            .iter()
+            .zip(self.vals.iter())
+            .map(|(&k, &v)| {
+                (
+                    make_string(k as usize, block),
+                    make_string(v as usize, block),
+                )
+            })
+            .find(|(key, _)| key == "oneway")
+            .map_or(false, |(_, value)| value == "yes")
     }
 }

--- a/src/codec/element/variants/way.rs
+++ b/src/codec/element/variants/way.rs
@@ -13,6 +13,7 @@ pub struct Way {
     id: i64,
     road_tag: Option<String>,
     one_way: bool,
+    roundabout: bool,
     refs: Vec<i64>,
 }
 
@@ -25,6 +26,10 @@ impl Way {
         self.one_way
     }
 
+    pub fn is_roundabout(&self) -> bool {
+        self.roundabout
+    }
+
     pub fn refs(&self) -> &Vec<i64> {
         &self.refs
     }
@@ -34,14 +39,17 @@ impl Way {
     }
 
     pub fn from_raw(value: &osm::Way, block: &PrimitiveBlock) -> Self {
+        let tags = value.tags(block);
+
         Way {
             id: value.id,
             refs: value.refs.iter().fold(vec![], |mut prior, current| {
                 prior.push(current + prior.last().unwrap_or(&0i64));
                 prior
             }),
-            road_tag: value.road_tag(block),
-            one_way: value.one_way(block),
+            road_tag: osm::Way::road_tag(&tags),
+            one_way: osm::Way::one_way(&tags),
+            roundabout: osm::Way::roundabout(&tags),
         }
     }
 }
@@ -71,8 +79,7 @@ const VALID_ROADWAYS: [&str; 12] = [
 ];
 
 impl osm::Way {
-    #[inline]
-    pub fn road_tag(&self, block: &PrimitiveBlock) -> Option<String> {
+    pub fn tags(&self, block: &PrimitiveBlock) -> Vec<(String, String)> {
         self.keys
             .iter()
             .zip(self.vals.iter())
@@ -82,22 +89,27 @@ impl osm::Way {
                     make_string(v as usize, block),
                 )
             })
-            .find(|(key, value)| key == "highway" && VALID_ROADWAYS.contains(&value.as_str()))
-            .map(|(_, value)| value)
+            .collect::<Vec<_>>()
     }
 
     #[inline]
-    pub fn one_way(&self, block: &PrimitiveBlock) -> bool {
-        self.keys
-            .iter()
-            .zip(self.vals.iter())
-            .map(|(&k, &v)| {
-                (
-                    make_string(k as usize, block),
-                    make_string(v as usize, block),
-                )
-            })
+    pub fn road_tag(tags: &Vec<(String, String)>) -> Option<String> {
+        tags.iter()
+            .find(|(key, value)| key == "highway" && VALID_ROADWAYS.contains(&value.as_str()))
+            .map(|(_, value)| value.clone())
+    }
+
+    #[inline]
+    pub fn one_way(tags: &Vec<(String, String)>) -> bool {
+        tags.iter()
             .find(|(key, _)| key == "oneway")
             .map_or(false, |(_, value)| value == "yes")
+    }
+
+    #[inline]
+    pub fn roundabout(tags: &Vec<(String, String)>) -> bool {
+        tags.iter()
+            .find(|(key, _)| key == "junction")
+            .map_or(false, |(_, value)| value == "roundabout")
     }
 }

--- a/src/codec/test.rs
+++ b/src/codec/test.rs
@@ -1,10 +1,10 @@
 #![cfg(test)]
 
 use log::error;
+#[cfg(not(feature = "mmap"))]
+use std::fs::File;
 use std::path::PathBuf;
 use std::time::Instant;
-#[cfg(not(feature = "mmap"))]
-use tokio::fs::File;
 
 use crate::codec::blob::iterator::BlobIterator;
 use crate::codec::block::item::BlockItem;

--- a/src/codec/test.rs
+++ b/src/codec/test.rs
@@ -1,10 +1,10 @@
 #![cfg(test)]
 
 use log::error;
-#[cfg(not(feature = "mmap"))]
-use std::fs::File;
 use std::path::PathBuf;
 use std::time::Instant;
+#[cfg(not(feature = "mmap"))]
+use tokio::fs::File;
 
 use crate::codec::blob::iterator::BlobIterator;
 use crate::codec::block::item::BlockItem;

--- a/src/codec/test.rs
+++ b/src/codec/test.rs
@@ -1,8 +1,6 @@
 #![cfg(test)]
 
 use log::error;
-#[cfg(not(feature = "mmap"))]
-use std::fs::File;
 use std::path::PathBuf;
 use std::time::Instant;
 

--- a/src/geo/cluster.rs
+++ b/src/geo/cluster.rs
@@ -5,11 +5,10 @@ use strum::{EnumCount, EnumIter, EnumProperty, VariantArray};
 #[cfg(feature = "tile")]
 use wkt::ToWkt;
 
-#[cfg(feature = "tile")]
-use crate::codec::mvt::Value;
 use crate::geo::coord::point::FeatureKey;
 use crate::geo::error::GeoError;
-use crate::geo::TileItem;
+#[cfg(feature = "tile")]
+use crate::{codec::mvt::Value, geo::TileItem};
 
 #[derive(PartialEq, Clone)]
 pub enum Classification {

--- a/src/route/graph.rs
+++ b/src/route/graph.rs
@@ -47,6 +47,10 @@ impl Debug for Graph {
 }
 
 impl Graph {
+    pub fn size(&self) -> usize {
+        self.hash.len()
+    }
+
     /// The weighting mapping of node keys to weight.
     pub fn weights<'a>() -> Result<HashMap<&'a str, Weight>, RouteError> {
         let weights: HashMap<&str, Weight> = HashMap::new();

--- a/src/route/graph.rs
+++ b/src/route/graph.rs
@@ -1,9 +1,9 @@
 use geo::{
-    coord, line_string, Destination, Distance, Euclidean, Geodesic, Haversine,
-    LineInterpolatePoint, LineLocatePoint, LineString, Point,
+    coord, line_string, Destination, Distance, Euclidean, Geodesic, LineInterpolatePoint,
+    LineLocatePoint, LineString, Point,
 };
 use log::{debug, error, info};
-use pathfinding::prelude::{astar, dijkstra_partial};
+use pathfinding::prelude::astar;
 use petgraph::prelude::DiGraphMap;
 use petgraph::visit::EdgeRef;
 use petgraph::Direction;
@@ -212,6 +212,7 @@ impl Graph {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(level = Level::INFO))]
+    #[inline]
     pub fn nearest_projected_nodes<'a>(
         &'a self,
         point: &'a Point,
@@ -268,7 +269,7 @@ impl Graph {
             |node| {
                 self.graph
                     .edges_directed(*node, Direction::Outgoing)
-                    .map(|(a, b, c)| (a, *c))
+                    .map(|(a, _b, c)| (a, *c))
             },
             |node| {
                 self.hash

--- a/src/route/graph.rs
+++ b/src/route/graph.rs
@@ -121,7 +121,7 @@ impl Graph {
                         way.refs().windows(2).for_each(|edge| {
                             if let [a, b] = edge {
                                 global_graph.lock().unwrap().add_edge(*a, *b, weight);
-                                if !way.is_one_way() {
+                                if !way.is_one_way() && !way.is_roundabout() {
                                     global_graph.lock().unwrap().add_edge(*b, *a, weight);
                                 }
                             } else {

--- a/src/route/graph.rs
+++ b/src/route/graph.rs
@@ -9,7 +9,7 @@ use petgraph::visit::EdgeRef;
 use petgraph::Direction;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rstar::{RTree, AABB};
-use scc::{Bag, HashMap};
+use scc::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::path::PathBuf;
 use std::sync::Mutex;

--- a/src/route/graph.rs
+++ b/src/route/graph.rs
@@ -116,6 +116,9 @@ impl Graph {
                         way.refs().windows(2).for_each(|edge| {
                             if let [a, b] = edge {
                                 global_graph.lock().unwrap().add_edge(*a, *b, weight);
+                                if !way.is_one_way() {
+                                    global_graph.lock().unwrap().add_edge(*b, *a, weight);
+                                }
                             } else {
                                 debug!("Edge windowing produced odd-sized entry: {:?}", edge);
                             }
@@ -246,7 +249,7 @@ impl Graph {
         points
             .iter()
             .map(|coord| {
-                let (lng, lat) = coord.x_y();
+                let (lng, lat) = coord.position.x_y();
                 coord! { x: lng, y: lat }
             })
             .collect::<LineString>()

--- a/src/route/graph.rs
+++ b/src/route/graph.rs
@@ -75,13 +75,13 @@ impl Graph {
     }
 
     /// Creates a graph from a `.osm.pbf` file, using the `ProcessedElementIterator`
-    pub async fn new(filename: std::ffi::OsString) -> crate::Result<Graph> {
+    pub fn new(filename: std::ffi::OsString) -> crate::Result<Graph> {
         let mut start_time = Instant::now();
         let fixed_start_time = Instant::now();
 
         let path = PathBuf::from(filename);
 
-        let reader = ProcessedElementIterator::new(path).await?;
+        let reader = ProcessedElementIterator::new(path)?;
         let weights = Graph::weights()?;
 
         debug!("Iterator warming took: {:?}", start_time.elapsed());
@@ -134,7 +134,7 @@ impl Graph {
                 a_tree.extend(b_tree);
                 a_tree
             },
-            || Vec::new(),
+            Vec::new,
         );
 
         let graph = global_graph.into_inner().unwrap();

--- a/src/route/graph.rs
+++ b/src/route/graph.rs
@@ -71,13 +71,13 @@ impl Graph {
     }
 
     /// Creates a graph from a `.osm.pbf` file, using the `ProcessedElementIterator`
-    pub fn new(filename: std::ffi::OsString) -> crate::Result<Graph> {
+    pub async fn new(filename: std::ffi::OsString) -> crate::Result<Graph> {
         let mut start_time = Instant::now();
         let fixed_start_time = Instant::now();
 
         let path = PathBuf::from(filename);
 
-        let reader = ProcessedElementIterator::new(path)?;
+        let reader = ProcessedElementIterator::new(path).await?;
         let weights = Graph::weights()?;
 
         debug!("Iterator warming took: {:?}", start_time.elapsed());

--- a/src/route/graph.rs
+++ b/src/route/graph.rs
@@ -36,9 +36,9 @@ const MAX_WEIGHT: Weight = 255 as Weight;
 /// Routing graph, can be ingested from an `.osm.pbf` file,
 /// and can be actioned upon using `route(start, end)`.
 pub struct Graph {
-    graph: GraphStructure,
+    pub(crate) graph: GraphStructure,
     pub(crate) index: RTree<Node>,
-    hash: HashMap<NodeIx, Node>,
+    pub(crate) hash: HashMap<NodeIx, Node>,
 }
 
 impl Debug for Graph {

--- a/src/route/transition/graph.rs
+++ b/src/route/transition/graph.rs
@@ -1,32 +1,63 @@
-use std::borrow::BorrowMut;
-use std::cell::RefCell;
-use std::cmp::Ordering;
 use std::f64::consts::E;
 use std::ops::{Div, Mul};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::Instant;
 
-use geo::{Distance, Haversine, Length, LineString, Point};
-use log::debug;
-use rayon::iter::{IndexedParallelIterator, ParallelIterator};
-use rayon::prelude::ParallelSlice;
+use geo::{Distance, Haversine, HaversineDistance, Length, LineString, Point, Relate};
+use log::{debug, error, info};
+use pathfinding::prelude::dijkstra_partial;
+use petgraph::graph::NodeIndex;
+use petgraph::{Directed, Graph};
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rayon::slice::ParallelSlice;
+use scc::HashMap;
 use wkt::ToWkt;
 
-use crate::route::transition::node::{
-    ImbuedLayer, TransitionCandidate, TransitionLayer, TransitionNode,
-};
-use crate::route::transition::segment::TrajectorySegment;
-use crate::route::Graph;
+use crate::route::transition::node::TransitionCandidate;
+use crate::route::Graph as RouteGraph;
 
 const DEFAULT_ERROR: f64 = 20f64;
 
+// NEW API:
+//
+// + === + === +
+//   \        /
+//    \     /
+//       +
+//
+// We need a way to represent the graph as a whole.
+// We will use petgraph's DiGraph for this,
+// since it will be a directed graph, built in reverse, tracking backwards.
+//
+// We must first add all the nodes into the graph,
+// then we can add the edges with their weights in
+// the transition.
+//
+// Finally, to backtrack, we can use the provided
+// algorithms to perform dijkstra on it to backtrack.
+// possibly just using the astar algo since the
+// api is easier to use.
+//
+
+type LayerId = usize;
+type NodeId = usize;
+
 pub struct Transition<'a> {
-    graph: &'a Graph,
+    map: &'a RouteGraph,
+    // keep in mind we dont need layerid and nodeid, but theyre useful for debugging so we'll keep for now.
+    graph: Arc<RwLock<Graph<Point, f64, Directed>>>,
+    candidates: HashMap<NodeIndex, (LayerId, NodeId, TransitionCandidate)>,
     error: Option<f64>,
 }
 
 impl<'a> Transition<'a> {
-    pub fn new(graph: &'a Graph) -> Self {
-        Transition { graph, error: None }
+    pub fn new(map: &'a RouteGraph) -> Self {
+        Transition {
+            map,
+            graph: Arc::new(RwLock::new(Graph::new())),
+            candidates: HashMap::new(),
+            error: None,
+        }
     }
 
     pub fn set_error(self, error: f64) -> Self {
@@ -38,7 +69,10 @@ impl<'a> Transition<'a> {
 
     /// Calculates the emission probability of `dist` (the GPS error from
     /// the observed point and matched point) with a given GPS `error`
-    fn emission_probability<K: Into<f64>, T: Div<Output = K> + Mul>(dist: T, error: T) -> f64 {
+    pub(crate) fn emission_probability<K: Into<f64>, T: Div<Output = K> + Mul>(
+        dist: T,
+        error: T,
+    ) -> f64 {
         let alpha: f64 = (dist / error).into();
         E.powf(-0.5f64 * alpha.powi(2))
     }
@@ -46,7 +80,7 @@ impl<'a> Transition<'a> {
     /// Calculates the transition probability of between two candidates
     /// given the `shortest_dist` between them, and the `euclidean_dist`
     /// of the segment we are transitioning over
-    fn transition_probability<K: Into<f64>, T: Div<Output = K> + PartialOrd>(
+    pub(crate) fn transition_probability<K: Into<f64>, T: Div<Output = K> + PartialOrd>(
         shortest_dist: T,
         euclidean_dist: T,
     ) -> f64 {
@@ -56,159 +90,166 @@ impl<'a> Transition<'a> {
         }
     }
 
+    /// Generates the layers of the transition graph, where each layer
+    /// represents a point in the linestring, and each node in the layer
+    /// represents a candidate transition point, within the `distance`
+    /// search radius of the linestring point, which was found by the
+    /// projection of the linestring point upon the closest edges within this radius.
+    pub fn generate_layers(&self, linestring: Vec<Point>, distance: f64) -> Vec<Vec<NodeIndex>> {
+        // Create the base transition graph
+        linestring
+            .par_iter()
+            .enumerate()
+            .map(|(layer_id, point)| {
+                self.map
+                    // We'll do a best-effort 100m2 search (square) radius
+                    .nearest_projected_nodes(point, distance)
+                    .enumerate()
+                    .map(|(node_id, (position, map_edge))| {
+                        // We have the actual projected position, and it's associated edge.
+                        let distance = Haversine::distance(position, *point);
+                        let emission_probability = Transition::emission_probability(
+                            distance,
+                            self.error.unwrap_or(DEFAULT_ERROR),
+                        );
+
+                        let candidate = TransitionCandidate {
+                            map_edge: (map_edge.0, map_edge.1),
+                            position,
+                            emission_probability,
+                        };
+
+                        let node_index = self.graph.write().unwrap().add_node(position);
+                        if let Err(error) = self
+                            .candidates
+                            .insert(node_index, (layer_id, node_id, candidate))
+                        {
+                            error!(
+                                "Failed to insert candidate transition probability. Error={:?}",
+                                error
+                            );
+                        }
+
+                        node_index
+                    })
+                    .collect::<Vec<NodeIndex>>()
+            })
+            .collect::<Vec<_>>()
+    }
+
     /// Refines the candidates into TransitionNodes with their respective
     /// emission and transition probabilities in the hidden markov model.
     ///
     /// Based on the method used in FMM
-    fn refine_candidates<'t>(&'t self, layer_a: &'t ImbuedLayer<'t>, layer_b: &'t ImbuedLayer<'t>) {
+    #[inline]
+    fn refine_candidates(&self, left_ix: NodeIndex, right_ix: NodeIndex) -> Option<f64> {
+        let left_candidate = self.candidates.get(&left_ix).unwrap().clone();
+        let right_candidate = self.candidates.get(&right_ix).unwrap().clone();
+
+        let left = left_candidate.2;
+        let right = right_candidate.2;
+
+        debug!(
+            "Routing from Layer::{}::{} to Layer::{}::{}.",
+            left_candidate.0, left_candidate.1, right_candidate.0, right_candidate.1,
+        );
+
         // TODO: Refactor how this works to it can be paralleled.
         // Now we modify the nodes to refine them
-        layer_a.iter().for_each(|node| {
-            debug!(
-                "Outward routing from {} to {} nodes",
-                node.borrow().candidate.index,
-                layer_b.len()
-            );
 
-            // Iterate for each sub-node to a node
-            layer_b
-                .iter()
-                // .filter(|b| node.borrow().candidate.index != b.borrow().candidate.index)
-                .for_each(|alt| {
-                    let mut time = Instant::now();
+        let mut time = Instant::now();
 
-                    debug!(
-                        "Transition is routing between {} and {}",
-                        node.borrow().candidate.index,
-                        alt.borrow().candidate.index
-                    );
-                    let start = node.borrow().candidate.edge.0;
-                    let end = alt.borrow().candidate.edge.0;
-                    debug!("TIMING: Obtain=@{}", time.elapsed().as_micros());
-                    time = Instant::now();
+        debug!(
+            "Transition is routing between {} and {}",
+            left.map_edge.0, right.map_edge.0
+        );
 
-                    match self.graph.route_raw(start, end) {
-                        Some((_, nodes)) => {
-                            debug!("TIMING: Route=@{}", time.elapsed().as_micros());
+        // Routing between these nodes is possibly incorrect...
+        // Since these represent the source node entry of the
+        // gathered nnode- is there a better way to "route" this
+        // maybe seen in FMM, where we consider **WHICH** node
+        // we should be routing from, SINCE it is directional.
+        let start = left.map_edge.0;
+        let end = right.map_edge.0;
 
-                            let direct_distance = Haversine::distance(
-                                node.borrow().candidate.position,
-                                alt.borrow().candidate.position,
-                            );
+        let threshold_distance = 20.0;
 
-                            debug!("TIMING: Distance=@{}", time.elapsed().as_micros());
+        // let paths = dijkstra_partial(
+        //     &start,
+        //     |node| self.map
+        //         .edges_directed(*node, Direction::Outgoing)
+        //         .map(|(a, b, c)| (a, *c)),
+        //     |node| HaversineDistance::distance(self.map..node.position, right.position) > threshold_distance
+        // ));
 
-                            // TODO: Consider doing this by default on route
-                            // TODO: Consider returning these nodes to "interpolate" the route
-                            let travel_distance = nodes
-                                .iter()
-                                .map(|node| node.position)
-                                .collect::<LineString>()
-                                .length::<Haversine>();
+        if left.map_edge.0 == right.map_edge.1 || right.map_edge.0 == left.map_edge.1 {
+            debug!("Found same edge, skipping route.");
+            return None;
+        }
 
-                            debug!("TIMING: TravelDistance=@{}", time.elapsed().as_micros());
+        debug!("TIMING: Obtain=@{}", time.elapsed().as_micros());
+        time = Instant::now();
 
-                            // Compare actual distance with straight-line-distance
-                            let transition_probability = Transition::transition_probability(
-                                travel_distance,
-                                direct_distance,
-                            );
+        let tp = match self.map.route_raw(start, end) {
+            Some((_, nodes)) => {
+                debug!("TIMING: Route=@{}", time.elapsed().as_micros());
+                let direct_distance = Haversine::distance(left.position, right.position);
+                debug!("TIMING: Distance=@{}", time.elapsed().as_micros());
 
-                            let net_probability = node.borrow().cumulative_probability
-                                + transition_probability.log(E)
-                                + alt.borrow().emission_probability.log(E);
+                // TODO: Consider doing this by default on route
+                // TODO: Consider returning these nodes to "interpolate" the route
+                let travel_distance = nodes
+                    .iter()
+                    .map(|node| node.position)
+                    .collect::<LineString>()
+                    .length::<Haversine>();
 
-                            debug!("TIMING: Probabilities=@{}", time.elapsed().as_micros());
+                debug!("TIMING: TravelDistance=@{}", time.elapsed().as_micros());
 
-                            // Only one-such borrow must exist at one time,
-                            // simply do not borrow again in this scope.
-                            let mut mutable_ptr = alt.borrow_mut();
+                // Compare actual distance with straight-line-distance
+                let transition_probability =
+                    Transition::transition_probability(travel_distance, direct_distance);
 
-                            debug!("TIMING: GettingMutBorrow=@{}", time.elapsed().as_micros());
+                debug!("TIMING: CommitChanges=@{}", time.elapsed().as_micros());
+                Some(transition_probability)
+            }
+            None => {
+                debug!("Found no route between nodes.");
+                None
+            }
+        };
 
-                            // Only if it probabilistic to route do we make the change
-                            if net_probability >= mutable_ptr.cumulative_probability {
-                                debug!("Committing changes, cumulative probability reached.");
+        debug!(
+            "TIMING: Full={} ({} -> {})",
+            time.elapsed().as_micros(),
+            left.position.wkt_string(),
+            right.position.wkt_string()
+        );
 
-                                // Extension...
-                                //
-                                // NodeRelation {
-                                //     node,
-                                //     // Storing other information is irrelevant,
-                                //     // as it means we loose paralellism, since
-                                //     // the information is relative to the node.
-                                //     transition_probability,
-                                //     path: nodes
-                                // }
-
-                                mutable_ptr.cumulative_probability = net_probability;
-                                mutable_ptr.transition_probability = transition_probability;
-                                mutable_ptr.prev_best = Some(node);
-                                *mutable_ptr.current_path.borrow_mut() = nodes;
-                            } else {
-                                debug!(
-                                    "Insufficient, cannot make change. Cumulative was: {}",
-                                    mutable_ptr.cumulative_probability
-                                );
-                            }
-
-                            debug!("TIMING: CommitChanges=@{}", time.elapsed().as_micros());
-                        }
-                        None => debug!("Found no route between nodes."),
-                    }
-
-                    debug!("TIMING: Full={}", time.elapsed().as_micros());
-                });
-        });
+        tp
     }
 
     /// Collapses transition layers, `layers`, into a single vector of
     /// the finalised points
-    fn collapse(&self, layers: &[ImbuedLayer]) -> Vec<Point> {
-        if let Some(nodes) = layers.last() {
-            // All nodes with a possible route, sorted by best probability
-            // TODO: A Dijkstra reverse search would yield better results as to route-depth and partial patching
-            let searchable = nodes
-                .iter()
-                .filter(|node| node.borrow().prev_best.is_some())
-                .max_by(|a, b| {
-                    a.borrow()
-                        .cumulative_probability
-                        .partial_cmp(&b.borrow().cumulative_probability)
-                        .unwrap_or(Ordering::Equal)
-                });
+    fn collapse(&self, start: NodeIndex, end: NodeIndex) -> Vec<Point> {
+        // Use the internal graph to backtrack using dijkstras.
+        // Make sure to add the start and end positions which are used
+        // to trace between as the target end-position. We're essentially
+        // looking for the shortest path through the graph, using the
+        // edge weighting as a consideration of the transition probability,
+        // determined in `refine_candidates`.
+        //
 
-            // Find the optimal candidate in last_layer.candidates
-            if let Some(best_node) = searchable {
-                return std::iter::from_fn({
-                    let mut previous_best = Some(best_node);
-                    move || {
-                        // Perform rollup on the candidates to walk-back the path
-                        previous_best.take().inspect(|prev| {
-                            previous_best = prev.borrow().prev_best;
-                        })
-                    }
-                })
-                .fuse()
-                .inspect(|node| {
-                    debug!(
-                        "Candidate {:?} ({}) selected.",
-                        node.borrow().candidate.index,
-                        node.borrow().candidate.position.wkt_string()
-                    )
-                })
-                .flat_map(|candidate|
-                        // TODO: Slow implementation..
-                        candidate.borrow().current_path
-                            .iter()
-                            .rev()
-                            .map(|item| item.position)
-                            .collect::<Vec<_>>())
-                .collect::<Vec<_>>()
-                .into_iter()
-                .rev()
+        let graph = self.graph.read().unwrap();
+        if let Some((score, path)) =
+            petgraph::algo::astar(&*graph, start, |node| node == end, |e| *e.weight(), |_| 0.0)
+        {
+            debug!("Minimal trip found with score of {score}.");
+            return path
+                .iter()
+                .filter_map(|node| self.candidates.get(node))
+                .map(|can| can.2.position)
                 .collect::<Vec<_>>();
-            }
         }
 
         // Return no points by default
@@ -218,131 +259,97 @@ impl<'a> Transition<'a> {
 
     /// Backtracks the HMM from the most appropriate final point to
     /// its prior most appropriate points
-    pub fn backtrack(&'a self, line_string: LineString, distance: f64) -> Vec<Point> {
+    ///
+    /// Consumes the graph.
+    pub fn backtrack(self, linestring: LineString, distance: f64) -> Vec<Point> {
         let time = Instant::now();
         debug!("BACKTRACK::TIMING:: Start=@{}", time.elapsed().as_micros());
 
+        let as_points = linestring.into_points();
+        let start = *as_points.first().unwrap();
+        let end = *as_points.last().unwrap();
+
         // Deconstruct the trajectory into individual segments
-        let points = line_string.into_points();
+        let layers = self.generate_layers(as_points, distance);
         debug!(
-            "BACKTRACK::TIMING:: GeneratePoints=@{}",
+            "BACKTRACK::TIMING:: GeneratedPoints=@{}",
             time.elapsed().as_micros()
         );
 
-        let layers = points
-            .as_parallel_slice()
+        // Add in the start and end points to the graph
+        let (source, target) = {
+            let mut graph = self.graph.write().unwrap();
+            let source = graph.add_node(start);
+            layers.first().unwrap().iter().for_each(|node| {
+                graph.add_edge(source, *node, 0.0f64);
+            });
+
+            let target = graph.add_node(end);
+            layers.last().unwrap().iter().for_each(|node| {
+                graph.add_edge(*node, target, 0.0f64);
+            });
+
+            drop(graph);
+            (source, target)
+        };
+
+        info!("Identified {} layers to backtrack.", layers.len());
+        let total_comp = layers
+            .windows(2)
+            .fold(0, |acc, layers| acc + (layers[0].len() * layers[1].len()));
+
+        info!(
+            "Performing a total of {} routes (Avg. 300us = {}us = {}ms - In series). Breakdown:",
+            total_comp,
+            total_comp * 300,
+            total_comp * 300 / 1000
+        );
+        for (index, layer) in layers.iter().enumerate() {
+            info!("Layer::{} has {} nodes.", index, layer.len());
+        }
+
+        // Declaring all the pairs of indicies that need to be refined.
+        //
+        // TODO: Consider how to parallise it too...
+        let transition_probabilities = layers
             .par_windows(2)
-            .map(|window| TrajectorySegment::new(&window[0], &window[1]))
-            .enumerate()
-            .filter_map(|(segment_index, segment)| {
-                debug!(
-                    "Looking for nodes adjacent to {}, within distance {}.",
-                    segment.source.wkt_string(),
-                    distance
-                );
-
-                let candidates = self
-                    .graph
-                    // We want exactly 10 candidates to search with
-                    .nearest_projected_nodes(segment.source, 5)
-                    .enumerate()
-                    .map(|(index, (position, edge))| TransitionCandidate {
-                        index: index as i64,
-                        edge,
-                        position,
-                    })
-                    .collect::<Vec<_>>();
-
-                debug!(
-                    "Obtained {} candidates for segment {}",
-                    candidates.len(),
-                    segment_index
-                );
-                if candidates.is_empty() {
-                    return None;
-                }
-
-                Some(TransitionLayer {
-                    candidates,
-                    segment,
-                })
+            .inspect(|pair| {
+                debug!("Unpacking {:?} and {:?}...", pair[0].len(), pair[1].len());
             })
-            .collect::<Vec<_>>();
-
-        // If we use the bridging technique
-        // from the above function, then this
-        // can be one iterator meaning we
-        // dont have to collect and re-create,
-        // thus can be paralellized completely.
-        debug!(
-            "BACKTRACK::TIMING:: GenerateLayers=@{}",
-            time.elapsed().as_micros()
-        );
-        debug!("Formed {} transition layers.", layers.len());
-
-        // We need to keep this in the outer-scope
-        let node_layers = layers
-            .iter()
-            // Only used for debug indexing
-            .enumerate()
-            .filter_map(|(layer_index, layer)| {
-                let candidates = layer
-                    .candidates
+            .flat_map(|vectors| {
+                vectors[0]
                     .iter()
-                    .map(|candidate| {
-                        let distance =
-                            Haversine::distance(candidate.position, *layer.segment.source);
-                        let emission_probability = Transition::emission_probability(
-                            distance,
-                            self.error.unwrap_or(DEFAULT_ERROR),
-                        );
-
-                        TransitionNode {
-                            candidate,
-                            prev_best: None,
-                            current_path: Box::new(vec![]),
-                            emission_probability,
-                            transition_probability: 0.0f64,
-                            cumulative_probability: if layer_index == 0 {
-                                emission_probability.log(E)
-                            } else {
-                                f64::NEG_INFINITY
-                            },
-                        }
-                    })
-                    .map(RefCell::new)
-                    .collect::<Vec<_>>();
-
-                if candidates.is_empty() {
-                    return None;
-                }
-
-                Some(candidates)
+                    .flat_map(|&a| vectors[1].iter().map(move |&b| (a, b)))
+                    .collect::<Vec<_>>()
+            })
+            .map(|(left, right)| {
+                debug!("Refining between {:?} and {:?}...", left, right);
+                (left, right, self.refine_candidates(left, right))
             })
             .collect::<Vec<_>>();
 
+        let route_size = transition_probabilities.len();
+        for (left, right, weight) in transition_probabilities {
+            debug!(
+                "Refined transition between {:?} and {:?} with TP(Weight)={:?}",
+                left, right, weight
+            );
+
+            if let Some(weight) = weight {
+                self.graph.write().unwrap().add_edge(left, right, weight);
+            }
+        }
+        info!("Made compute for {} total routings.", route_size);
+
         debug!(
-            "BACKTRACK::TIMING:: GenerateAllNodes=@{}",
+            "BACKTRACK::TIMING:: RefinedLayers=@{}",
             time.elapsed().as_micros()
         );
-        debug!("All {} layer nodes generated", node_layers.len());
 
-        // Refine Step
-        let mut layer_index = 0;
-        node_layers.windows(2).for_each(|layers| {
-            debug!("Moving onto layers {}", layer_index);
-            self.refine_candidates(&layers[0], &layers[1]);
-            layer_index += 1;
-        });
-
-        debug!(
-            "BACKTRACK::TIMING:: RefineLayers=@{}",
-            time.elapsed().as_micros()
-        );
         debug!("Refined all layers, collapsing...");
 
         // Now we refine the candidates
-        let collapsed = self.collapse(&node_layers);
+        let collapsed = self.collapse(source, target);
         debug!(
             "BACKTRACK::TIMING:: Collapsed=@{}",
             time.elapsed().as_micros()

--- a/src/route/transition/graph.rs
+++ b/src/route/transition/graph.rs
@@ -54,7 +54,7 @@ type LayerId = usize;
 type NodeId = usize;
 
 #[derive(Clone, Copy, Debug)]
-struct TransitionPair<K>
+pub struct TransitionPair<K>
 where
     K: Into<f64> + Div<Output = K> + PartialOrd,
 {

--- a/src/route/transition/mod.rs
+++ b/src/route/transition/mod.rs
@@ -1,3 +1,6 @@
 pub mod graph;
 pub mod node;
 pub mod segment;
+
+#[cfg(test)]
+mod test;

--- a/src/route/transition/node.rs
+++ b/src/route/transition/node.rs
@@ -9,7 +9,7 @@ pub type ImbuedLayer<'t> = Vec<RefCell<TransitionNode<'t>>>;
 
 #[derive(Clone)]
 pub struct TransitionNode<'a> {
-    pub candidate: &'a TransitionCandidate<'a>,
+    pub candidate: &'a TransitionCandidate,
     pub prev_best: Option<&'a RefCell<TransitionNode<'a>>>,
     pub current_path: Box<Vec<Node>>,
     pub emission_probability: f64,
@@ -23,12 +23,16 @@ pub struct RefinedTransitionLayer<'a> {
 }
 
 pub struct TransitionLayer<'a> {
-    pub candidates: Vec<TransitionCandidate<'a>>,
+    pub candidates: Vec<TransitionCandidate>,
     pub segment: TrajectorySegment<'a>,
 }
 
-pub struct TransitionCandidate<'a> {
-    pub index: NodeIx,
-    pub edge: Edge<'a>,
+// Transition probability is kept
+// on the node's edge toward the next/prev
+// in the graph from [`crate::transition`].
+#[derive(Clone, Copy, Debug)]
+pub struct TransitionCandidate {
+    pub map_edge: (NodeIx, NodeIx),
     pub position: Point,
+    pub emission_probability: f64,
 }

--- a/src/route/transition/node.rs
+++ b/src/route/transition/node.rs
@@ -2,7 +2,7 @@ use geo::Point;
 use std::cell::RefCell;
 
 use crate::codec::element::variants::Node;
-use crate::route::graph::{Edge, NodeIx};
+use crate::route::graph::NodeIx;
 use crate::route::transition::segment::TrajectorySegment;
 
 pub type ImbuedLayer<'t> = Vec<RefCell<TransitionNode<'t>>>;

--- a/src/route/transition/test.rs
+++ b/src/route/transition/test.rs
@@ -1,0 +1,212 @@
+use std::{
+    path::Path,
+    sync::{Arc, LazyLock, Mutex},
+    thread::sleep,
+    time::{Duration, Instant},
+};
+
+use geo::{
+    coord, point, wkt, Coord, Destination, Distance, Geodesic, Haversine, HaversineDestination,
+    MapCoordsInPlace,
+};
+use petgraph::{graph::NodeIndex, Directed, Graph as Petgraph};
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rstar::AABB;
+
+use crate::{codec::consts::SYDNEY, route::Graph};
+
+use super::{graph::Transition, node::TransitionCandidate};
+
+static GLOBAL_GRAPH: LazyLock<Graph> = LazyLock::new(|| {
+    let path = Path::new(SYDNEY);
+    Graph::new(path.as_os_str().to_ascii_lowercase()).expect("Couldn't create graph.")
+});
+
+#[test]
+fn test_transition() {
+    env_logger::init();
+    println!("Graph Created. Transitioning...");
+
+    let now = Instant::now();
+    let transition = Transition::new(&GLOBAL_GRAPH);
+    let linestring = wkt! {
+        LINESTRING (151.19462 -33.885309, 151.193783 -33.887126, 151.189685 -33.890243, 151.185329 -33.892915, 151.179487 -33.896864, 151.178023 -33.898694, 151.179283 -33.902523, 151.181273 -33.906295, 151.184916 -33.907203, 151.187641 -33.906851, 151.189315 -33.905061, 151.192024 -33.902145, 151.19432 -33.899576, 151.194438 -33.898957, 151.19425 -33.898556)
+    };
+    println!(
+        "[TRANSITION] Init. Elapsed: {}us (us = 0.001 ms)",
+        now.elapsed().as_micros()
+    );
+
+    let now = Instant::now();
+    let points = transition.backtrack(linestring, 100.0);
+    println!(
+        "[TRANSITION] Backtracked. Elapsed: {}us (us = 0.001 ms)",
+        now.elapsed().as_micros()
+    );
+
+    assert!(points.len() > 1);
+}
+
+#[test]
+fn nearest_nodes() {
+    let now = Instant::now();
+    let path = Path::new(SYDNEY);
+    let graph = Graph::new(path.as_os_str().to_ascii_lowercase()).expect("Couldn't create graph.");
+    println!(
+        "[INGEST] {} Elapsed: {}us (us = 0.001 ms)",
+        graph.size(),
+        now.elapsed().as_micros()
+    );
+
+    // Using nearest edges
+    let now = Instant::now();
+    let point = wkt! { POINT(151.183886 -33.885197) };
+
+    println!("Point: {:?}", point);
+
+    // 100m2 search radius
+
+    let bottom_right = Geodesic::destination(point, 135.0, 100.0);
+    let top_left = Geodesic::destination(point, 315.0, 100.0);
+    let bbox = AABB::from_corners(top_left, bottom_right);
+
+    println!("BBox: {:?}", bbox);
+
+    let nearest = graph.index().locate_in_envelope(&bbox).collect::<Vec<_>>();
+    assert_eq!(nearest.len(), 9);
+
+    println!(
+        "[NEAREST_DISTANCE_RADIUS_100(2)] Elapsed: {}us (us = 0.001 ms)",
+        now.elapsed().as_micros()
+    );
+
+    // Using nearest edges
+    let now = Instant::now();
+    let point = wkt! { POINT(151.183886 -33.885197) };
+    let nearest = graph.nearest_edges(&point, 100.0).collect::<Vec<_>>();
+    assert!(nearest.len() > 1);
+
+    println!(
+        "[NEAREST_EDGES] Elapsed: {}us (us = 0.001 ms)",
+        now.elapsed().as_micros()
+    );
+
+    // Using nearest projected
+    let now = Instant::now();
+    let point = wkt! { POINT(151.183886 -33.885197) };
+    let nearest = graph.nearest_projected_nodes(&point, 100.0);
+    assert_eq!(nearest.collect::<Vec<_>>().len(), 10);
+
+    println!(
+        "[NEAREST_PROJECTED] Elapsed: {}us (us = 0.001 ms)",
+        now.elapsed().as_micros()
+    );
+}
+
+#[test]
+fn test_par_layers() {
+    type LayerId = usize;
+    type NodeId = usize;
+
+    let now = Instant::now();
+    let path = Path::new(SYDNEY);
+    let graph = Graph::new(path.as_os_str().to_ascii_lowercase()).expect("Couldn't create graph.");
+
+    let petgraph: Arc<Mutex<Petgraph<(LayerId, NodeId, TransitionCandidate), i32, Directed>>> =
+        Arc::new(Mutex::new(Petgraph::new()));
+
+    let distance = 100.0;
+    let linestring = wkt! {
+        LINESTRING (151.19462 -33.885309, 151.193783 -33.887126, 151.189685 -33.890243, 151.185329 -33.892915, 151.179487 -33.896864, 151.178023 -33.898694, 151.179283 -33.902523, 151.181273 -33.906295, 151.184916 -33.907203, 151.187641 -33.906851, 151.189315 -33.905061, 151.192024 -33.902145, 151.19432 -33.899576, 151.194438 -33.898957, 151.19425 -33.898556)
+    };
+
+    let now = Instant::now();
+    let layers = linestring
+        .into_points()
+        .par_iter()
+        .enumerate()
+        .map(|(layer_id, point)| {
+            graph
+                // We'll do a best-effort 100m2 search (square) radius
+                .nearest_projected_nodes(point, distance)
+                .enumerate()
+                .map(|(node_id, (position, map_edge))| {
+                    // We have the actual projected position, and it's associated edge.
+                    let distance = Haversine::distance(position, *point);
+                    let emission_probability = Transition::emission_probability(distance, 20.0);
+
+                    let candidate = TransitionCandidate {
+                        map_edge: (map_edge.0, map_edge.1),
+                        position,
+                        emission_probability,
+                    };
+
+                    let node_index = petgraph
+                        .lock()
+                        .unwrap()
+                        .add_node((layer_id, node_id, candidate));
+
+                    node_index
+                })
+                .collect::<Vec<NodeIndex>>()
+        })
+        .collect::<Vec<_>>();
+
+    println!(
+        "[LAYERS] Elapsed: {}us (us = 0.001 ms)",
+        now.elapsed().as_micros()
+    );
+    assert_eq!(layers.len(), 12);
+}
+
+#[test]
+fn test_series_layers() {
+    type LayerId = usize;
+    type NodeId = usize;
+
+    let path = Path::new(SYDNEY);
+    let graph = Graph::new(path.as_os_str().to_ascii_lowercase()).expect("Couldn't create graph.");
+
+    let mut petgraph: Petgraph<(LayerId, NodeId, TransitionCandidate), i32, Directed> =
+        Petgraph::new();
+
+    let distance = 100.0;
+    let linestring = wkt! {
+        LINESTRING (151.19462 -33.885309, 151.193783 -33.887126, 151.189685 -33.890243, 151.185329 -33.892915, 151.179487 -33.896864, 151.178023 -33.898694, 151.179283 -33.902523, 151.181273 -33.906295, 151.184916 -33.907203, 151.187641 -33.906851, 151.189315 -33.905061, 151.192024 -33.902145, 151.19432 -33.899576, 151.194438 -33.898957, 151.19425 -33.898556)
+    };
+
+    let now = Instant::now();
+    let layers = linestring
+        .into_points()
+        .iter()
+        .enumerate()
+        .map(|(layer_id, point)| {
+            graph
+                // We'll do a best-effort 100m2 search (square) radius
+                .nearest_projected_nodes(point, distance)
+                .enumerate()
+                .map(|(node_id, (position, map_edge))| {
+                    // We have the actual projected position, and it's associated edge.
+                    let distance = Haversine::distance(position, *point);
+                    let emission_probability = Transition::emission_probability(distance, 20.0);
+
+                    let candidate = TransitionCandidate {
+                        map_edge: (map_edge.0, map_edge.1),
+                        position,
+                        emission_probability,
+                    };
+
+                    let node_index = petgraph.add_node((layer_id, node_id, candidate));
+
+                    node_index
+                })
+                .collect::<Vec<NodeIndex>>()
+        })
+        .collect::<Vec<_>>();
+
+    println!(
+        "[LAYERS] Elapsed: {}us (us = 0.001 ms)",
+        now.elapsed().as_micros()
+    );
+    assert_eq!(layers.len(), 12);
+}

--- a/src/route/transition/test.rs
+++ b/src/route/transition/test.rs
@@ -39,12 +39,12 @@ async fn test_transition() {
 
     println!("Graph Created. Transitioning...");
 
-    let now = Instant::now();
-    let transition = Transition::new(&GLOBAL_GRAPH);
-
     let linestring = wkt! {
         LINESTRING (151.19462 -33.885309, 151.193783 -33.887126,151.189685 -33.890243, 151.185329 -33.892915, 151.179487 -33.896864, 151.178023 -33.898694, 151.179283 -33.902523, 151.181273 -33.906295, 151.184916 -33.907203, 151.187641 -33.906851, 151.189315 -33.905061, 151.192024 -33.902145, 151.19432 -33.899576, 151.194438 -33.898957, 151.19425 -33.898556)
     };
+
+    let now = Instant::now();
+    let transition = Transition::new(&GLOBAL_GRAPH, linestring);
 
     println!(
         "[TRANSITION] Init. Elapsed: {}us (us = 0.001 ms)",
@@ -52,7 +52,8 @@ async fn test_transition() {
     );
 
     let now = Instant::now();
-    let points = transition.backtrack(linestring, 50.0);
+    let mres = transition.generate_probabilities(50.0).backtrack();
+
     println!(
         "[TRANSITION] Backtracked. Elapsed: {}us (us = 0.001 ms)",
         now.elapsed().as_micros()
@@ -60,14 +61,14 @@ async fn test_transition() {
 
     println!(
         "[TRANSITION] Backtracked. {}",
-        points
+        mres.matched
             .iter()
             .map(|v| v.position)
             .collect::<LineString>()
             .wkt_string()
     );
 
-    assert!(points.len() > 1);
+    assert!(mres.matched.len() > 1);
 }
 
 #[test]

--- a/src/route/transition/test.rs
+++ b/src/route/transition/test.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use geo::{wkt, Destination, Distance, Geodesic, Haversine, LineString};
-use log::debug;
 use petgraph::{graph::NodeIndex, Directed, Graph as Petgraph};
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use rstar::AABB;

--- a/src/route/transition/test.rs
+++ b/src/route/transition/test.rs
@@ -7,11 +7,12 @@ use std::{
 
 use geo::{
     coord, point, wkt, Coord, Destination, Distance, Geodesic, Haversine, HaversineDestination,
-    MapCoordsInPlace,
+    LineString, MapCoordsInPlace,
 };
 use petgraph::{graph::NodeIndex, Directed, Graph as Petgraph};
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use rstar::AABB;
+use wkt::ToWkt;
 
 use crate::{codec::consts::SYDNEY, route::Graph};
 
@@ -29,9 +30,11 @@ fn test_transition() {
 
     let now = Instant::now();
     let transition = Transition::new(&GLOBAL_GRAPH);
+
     let linestring = wkt! {
-        LINESTRING (151.19462 -33.885309, 151.193783 -33.887126, 151.189685 -33.890243, 151.185329 -33.892915, 151.179487 -33.896864, 151.178023 -33.898694, 151.179283 -33.902523, 151.181273 -33.906295, 151.184916 -33.907203, 151.187641 -33.906851, 151.189315 -33.905061, 151.192024 -33.902145, 151.19432 -33.899576, 151.194438 -33.898957, 151.19425 -33.898556)
+        LINESTRING (151.19462 -33.885309, 151.193783 -33.887126,151.189685 -33.890243, 151.185329 -33.892915, 151.179487 -33.896864, 151.178023 -33.898694, 151.179283 -33.902523, 151.181273 -33.906295, 151.184916 -33.907203, 151.187641 -33.906851, 151.189315 -33.905061, 151.192024 -33.902145, 151.19432 -33.899576, 151.194438 -33.898957, 151.19425 -33.898556)
     };
+
     println!(
         "[TRANSITION] Init. Elapsed: {}us (us = 0.001 ms)",
         now.elapsed().as_micros()
@@ -42,6 +45,15 @@ fn test_transition() {
     println!(
         "[TRANSITION] Backtracked. Elapsed: {}us (us = 0.001 ms)",
         now.elapsed().as_micros()
+    );
+
+    println!(
+        "[TRANSITION] Backtracked. {}",
+        points
+            .iter()
+            .map(|v| v.position)
+            .collect::<LineString>()
+            .wkt_string()
     );
 
     assert!(points.len() > 1);

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -30,9 +30,9 @@ pub struct RouteService {
 }
 
 impl RouteService {
-    pub async fn from_file(file: &str) -> crate::Result<RouteService> {
+    pub fn from_file(file: &str) -> crate::Result<RouteService> {
         let path = Path::new(file);
-        let graph = Graph::new(path.as_os_str().to_ascii_lowercase()).await?;
+        let graph = Graph::new(path.as_os_str().to_ascii_lowercase())?;
 
         Ok(RouteService { graph })
     }

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -74,10 +74,7 @@ impl RouterService for RouteService {
                     })
                     .collect();
 
-                Ok(Response::new(RouteResponse {
-                    cost: cost as u32,
-                    shape,
-                }))
+                Ok(Response::new(RouteResponse { cost, shape }))
             },
         )
     }
@@ -167,7 +164,7 @@ impl RouterService for RouteService {
             dist_to_a.partial_cmp(&dist_to_b).unwrap_or(Ordering::Equal)
         });
 
-        let nearest_point = nearest_points.get(0).map_or(
+        let nearest_point = nearest_points.first().map_or(
             Err(Status::internal("Could not find appropriate point")),
             |(coord, _)| {
                 Ok(Coordinate {

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -30,9 +30,9 @@ pub struct RouteService {
 }
 
 impl RouteService {
-    pub fn from_file(file: &str) -> crate::Result<RouteService> {
+    pub async fn from_file(file: &str) -> crate::Result<RouteService> {
         let path = Path::new(file);
-        let graph = Graph::new(path.as_os_str().to_ascii_lowercase())?;
+        let graph = Graph::new(path.as_os_str().to_ascii_lowercase()).await?;
 
         Ok(RouteService { graph })
     }

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -146,13 +146,13 @@ impl RouterService for RouteService {
             .map_err(|err| Status::internal(format!("{:?}", err)))?;
 
         info!(
-            "Got request for {} for distances <= {}",
+            "Got request for {} for nodes within {} square meters",
             point.wkt_string(),
-            request.quantity
+            request.search_radius
         );
         let mut nearest_points = self
             .graph
-            .nearest_projected_nodes(&point, request.quantity as usize)
+            .nearest_projected_nodes(&point, request.search_radius)
             .collect::<Vec<_>>();
 
         debug!("Found {} points", nearest_points.len());


### PR DESCRIPTION
The concept of an Upper-Bounded Dijkstra works due to the search-nature of the Dijkstra algorithm. Primarily, since the smallest consecutive weight will be travelled, we can simply make the weights the length of the edge. Thus, we can include a boundary for which there are no more nodes after an aggregated weight greater than the upper-bound, $N$. Thus, we do not implement a search radius discretely, but rather a cap by travelled distance to prevent run-away searches that can accumulate large distances whilst remaining within a small search radius. This is implemented in the following PR.
  
### General Changes
- Includes ingest benchmarks (`benches/total_ingestion.rs`)
- Changes `quantity` for nearest nodes into a `search_radius`
- Node distance estimation optimised with Euclidean distances for small gaps [?] (`.../variants/node.rs`)
- Includes context understanding implementing bidirectional edges for one/dual + roundabout ways
- Graph ingestion moves to a global state (Incurs higher drop-cost but lower startup cost: See benchmarks)
- Implements `square_scan`, which queries using an Axis-Aligned Bounding Box with diagonal length `distance`, over 100x faster than a "take N sorted nearest" approach.
- Refactors `nearest_edges` to prefer square scan
- Makes possibility-generation and backtracking discrete steps, allowing for saving/committing a partially-produced graph (This is to be revisited)

### Transition Changes
The reach-dijkstra approach means that instead of performing $Fn(a) \to b$ for all $a$ in layer A and $b$ in layer B, we instead generate $Fn(a) \to B$ in the same compute timing (~). Thus, saving $B$ times the performance per iteration. It is possible that we can re-use the cache of the UBD (Upper-Bounded Dijkstra) for future iterations, thus saving $A \times B$, and converting the big-O cost from $O(n^2)$ to $O(n)$ (This PR), and finally $O(1)$ (If it was bidi) between layers. Where this cost is further multiplied by the number of between-layers $N-1$, and the cost of the search $O(|E| + |V|log |V|)$, thus this PR reduces it from $O(|E_1| + (N-1)^2 \times |V_1| \times log |V_1|)$ to $O(|E_2| + (N-1) \times |V_2| log |V_2|)$. Where $|V_2| <= |V_1|$ since this query is bounded (less or equal no. nodes), unlike the prior.

- TransitionCandidate no longer needs to be a reference.
- Refactor transition probability calculation to take in a pair, `TransitionPair` and return a `TransitionProbability`, to alleviate type ambiguity.
- TransitionGraph now generates a directed internal graph which is save-able, consistent. It stores the node relations with edge weights as TP and node weights as EP.
- Further, it stores the layers and points in/generated-from the source linestring
- Updates emission probability algorithm to avoid `ln(e^(...))` over-calculation
- Implements internal `pathbuilder` to take advantage of stronger type constraints.
- Implements `generate_layers` function which computes the layer candidates and their associated emission probabilities.
- Refactors `refine_candidates` to no longer take layer references, but use node indices from the candidate graph (mentioned above) to perform a reached Dijkstra from L-to-R. 
- Generates interpolated and matched-paths for each
- Does NOT handle failed-match re-stitching (Future task)
- Collapses without performing recursive address searching, but instead A* over the candidate transition graph
- Parallelised probability generation, and makes access to sections discrete such that read and write contention is minimal.
- Uses custom-formula for TP and EP.
- Collapses matched route into a `MatchResult`.